### PR TITLE
cobs_decode: fix buffer overflow

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: docker.pkg.github.com/charlesnicholson/docker-images/docker-image:latest
       credentials:
-        username: ${{ github.actor }}
+        username: charlesnicholson
         password: ${{ secrets.PACKAGE_READ_TOKEN }}
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SRCS := cobs.c \
 		tests/test_cobs_encode_max.cc \
 		tests/test_cobs_encode.cc \
 		tests/test_cobs_encode_inplace.cc \
+		tests/test_cobs_decode.cc \
 		tests/test_cobs_decode_inplace.cc \
 		tests/test_paper_figures.cc \
 		tests/test_wikipedia.cc \

--- a/cobs.c
+++ b/cobs.c
@@ -107,6 +107,7 @@ cobs_ret_t cobs_decode(void const *enc,
   while (src < end) {
     unsigned const code = *src++;
     if (!code) { return COBS_RET_ERR_BAD_PAYLOAD; }
+    if (src + code - 1 > end) { return COBS_RET_ERR_BAD_PAYLOAD; }
 
     dec_len += code - 1;
     if (dec_len > dec_max) { return COBS_RET_ERR_EXHAUSTED; }

--- a/tests/test_cobs_decode.cc
+++ b/tests/test_cobs_decode.cc
@@ -1,0 +1,16 @@
+#include "../cobs.h"
+#include "catch.hpp"
+
+#include <cstring>
+
+TEST_CASE("Decoding validation", "[cobs_decode]") {
+  unsigned char enc[32], dec[32];
+  unsigned dec_len;
+
+  SECTION("Invalid payload") {
+    // first byte jumps past end
+    enc[0] = 3;
+    enc[1] = 0;
+    REQUIRE( cobs_decode(&enc, 2, dec, sizeof(enc), &dec_len) == COBS_RET_ERR_BAD_PAYLOAD );
+  }
+}


### PR DESCRIPTION
A malformed encoding may have the overhead byte pointing to a location outside the buffer contents. This malformed encoding causes an out of bounds memory access. This commit explicitly checks the invalid condition doesn’t happen, and bails if so.

Such malformed encoding will never be produced by a proper encoder, but someone messing with the framer doesn’t need to restrict themselves to feed only compliant encodings.