### PR TITLE
move to the new ghcr.io registry and use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -11,6 +11,9 @@ jobs:
   linux-gcc:
     runs-on: ubuntu-latest
 
+    permissions:
+      packages: read
+
     container:
       image: ghcr.io/charlesnicholson/docker-image:latest
       credentials:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -3,20 +3,24 @@ name: Presubmit Checks
 on:
   pull_request:
     branches: [ main ]
+
   schedule:
     - cron: '0 2 * * 0'  # Weekly
 
 jobs:
   linux-gcc:
     runs-on: ubuntu-latest
+
     container:
-      image: docker.pkg.github.com/charlesnicholson/docker-images/docker-image:latest
+      image: ghcr.io/charlesnicholson/docker-image:latest
       credentials:
-        username: charlesnicholson
-        password: ${{ secrets.PACKAGE_READ_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     strategy:
       matrix:
         architecture: [32, 64]
+
     steps:
       - uses: actions/checkout@v2
       - name: Build
@@ -24,6 +28,7 @@ jobs:
 
   macos:
     runs-on: macos-latest
+
     steps:
       - uses: actions/checkout@v2
       - name: Build
@@ -31,9 +36,11 @@ jobs:
 
   win:
     runs-on: windows-latest
+
     strategy:
       matrix:
         architecture: [32, 64]
+
     steps:
       - uses: actions/checkout@v2
       - name: Build


### PR DESCRIPTION
This PR doesn't change any source code; it just migrates away from using a PAT for container auth. Now we use `GITHUB_TOKEN` and the new ghcr.io registry, which gives dynamic permissions based on who's opening PRs and running CI.

Hopefully this mitigates @oreparaz's unpleasant experience where a helpful change was waylaid by CI permissions :-|