### PR TITLE
Indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It's pretty small.
 00000048 00000032 T cobs_decode_inplace  (50 bytes)
 00000000 00000048 T cobs_encode_inplace  (72 bytes)
 00000092 0000007a T cobs_encode          (122 bytes)
-0000010c 00000084 T cobs_decode          (132 bytes)
+0000010c 0000008c T cobs_decode          (140 bytes)
 ```
 
 ## Usage

--- a/cobs.c
+++ b/cobs.c
@@ -63,8 +63,10 @@ cobs_ret_t cobs_encode(void const *dec,
   cobs_byte_t *code_dst = dst++;
   cobs_byte_t code = 1;
 
+  unsigned src_idx = 0;
+
   while (dec_len--) {
-    cobs_byte_t const byte = *src;
+    cobs_byte_t const byte = src[src_idx];
     if (byte) {
       *dst = byte;
       if (++dst >= dst_max) { return COBS_RET_ERR_EXHAUSTED; }
@@ -80,7 +82,7 @@ cobs_ret_t cobs_encode(void const *dec,
         if (++dst >= dst_max) { return COBS_RET_ERR_EXHAUSTED; }
       }
     }
-    ++src;
+    ++src_idx;
   }
 
   *code_dst = code;

--- a/cobs.c
+++ b/cobs.c
@@ -57,37 +57,35 @@ cobs_ret_t cobs_encode(void const *dec,
   if (!dec || !out_enc || !out_enc_len) { return COBS_RET_ERR_BAD_ARG; }
   if ((enc_max < 2) || (enc_max < dec_len)) { return COBS_RET_ERR_BAD_ARG; }
 
-  cobs_byte_t const *src = (cobs_byte_t const *)dec;
-  cobs_byte_t *dst = (cobs_byte_t *)out_enc;
-  cobs_byte_t const *const dst_max = dst + enc_max;
-  cobs_byte_t *code_dst = dst++;
-  cobs_byte_t code = 1;
+  cobs_byte_t const *const src = (cobs_byte_t const *)dec;
+  cobs_byte_t *const dst = (cobs_byte_t *)out_enc;
 
-  unsigned src_idx = 0;
+  unsigned src_idx = 0, dst_code_idx = 0, dst_idx = 1;
+  cobs_byte_t code = 1;
 
   while (dec_len--) {
     cobs_byte_t const byte = src[src_idx];
     if (byte) {
-      *dst = byte;
-      if (++dst >= dst_max) { return COBS_RET_ERR_EXHAUSTED; }
+      dst[dst_idx] = byte;
+      if (++dst_idx >= enc_max) { return COBS_RET_ERR_EXHAUSTED; }
       ++code;
     }
 
     if ((byte == 0) || (code == 0xFF)) {
-      *code_dst = code;
-      code_dst = dst;
+      dst[dst_code_idx] = code;
+      dst_code_idx = dst_idx;
       code = 1;
 
       if ((byte == 0) || dec_len) {
-        if (++dst >= dst_max) { return COBS_RET_ERR_EXHAUSTED; }
+        if (++dst_idx >= enc_max) { return COBS_RET_ERR_EXHAUSTED; }
       }
     }
     ++src_idx;
   }
 
-  *code_dst = code;
-  *dst++ = 0;
-  *out_enc_len = (unsigned)(dst - (cobs_byte_t *)out_enc);
+  dst[dst_code_idx] = code;
+  dst[dst_idx++] = 0;
+  *out_enc_len = dst_idx;
   return COBS_RET_SUCCESS;
 }
 

--- a/cobs.c
+++ b/cobs.c
@@ -102,19 +102,19 @@ cobs_ret_t cobs_decode(void const *enc,
   if (!*src || *end) { return COBS_RET_ERR_BAD_PAYLOAD; }
 
   cobs_byte_t *dst = (cobs_byte_t *)out_dec;
-  unsigned dst_idx = 0;
+  unsigned src_idx = 0, dst_idx = 0;
 
-  while (src < end) {
-    unsigned const code = *src++;
+  while (src + src_idx < end) {
+    unsigned const code = src[src_idx++];
     if (!code) { return COBS_RET_ERR_BAD_PAYLOAD; }
-    if (src + code - 1 > end) { return COBS_RET_ERR_BAD_PAYLOAD; }
+    if (src + src_idx + code - 1 > end) { return COBS_RET_ERR_BAD_PAYLOAD; }
 
     if ((dst_idx + code - 1) > dec_max) { return COBS_RET_ERR_EXHAUSTED; }
     for (unsigned i = 0; i < code - 1; ++i) {
-      dst[dst_idx++] = *src++;
+      dst[dst_idx++] = src[src_idx++];
     }
 
-    if ((src < end) && (code < 0xFF)) {
+    if ((src + src_idx < end) && (code < 0xFF)) {
       if ((dst_idx + 1) > dec_max) { return COBS_RET_ERR_EXHAUSTED; }
       dst[dst_idx++] = 0;
     }

--- a/cobs.c
+++ b/cobs.c
@@ -102,7 +102,7 @@ cobs_ret_t cobs_decode(void const *enc,
   if (!*src || *end) { return COBS_RET_ERR_BAD_PAYLOAD; }
 
   cobs_byte_t *dst = (cobs_byte_t *)out_dec;
-  unsigned dec_len = 0;
+  unsigned dst_idx = 0, dec_len = 0;
 
   while (src < end) {
     unsigned const code = *src++;
@@ -112,12 +112,12 @@ cobs_ret_t cobs_decode(void const *enc,
     dec_len += code - 1;
     if (dec_len > dec_max) { return COBS_RET_ERR_EXHAUSTED; }
     for (unsigned i = 0; i < code - 1; ++i) {
-      *dst++ = *src++;
+      dst[dst_idx++] = *src++;
     }
 
     if ((src < end) && (code < 0xFF)) {
       if (++dec_len > dec_max) { return COBS_RET_ERR_EXHAUSTED; }
-      *dst++ = 0;
+      dst[dst_idx++] = 0;
     }
   }
 

--- a/cobs.c
+++ b/cobs.c
@@ -102,25 +102,24 @@ cobs_ret_t cobs_decode(void const *enc,
   if (!*src || *end) { return COBS_RET_ERR_BAD_PAYLOAD; }
 
   cobs_byte_t *dst = (cobs_byte_t *)out_dec;
-  unsigned dst_idx = 0, dec_len = 0;
+  unsigned dst_idx = 0;
 
   while (src < end) {
     unsigned const code = *src++;
     if (!code) { return COBS_RET_ERR_BAD_PAYLOAD; }
     if (src + code - 1 > end) { return COBS_RET_ERR_BAD_PAYLOAD; }
 
-    dec_len += code - 1;
-    if (dec_len > dec_max) { return COBS_RET_ERR_EXHAUSTED; }
+    if ((dst_idx + code - 1) > dec_max) { return COBS_RET_ERR_EXHAUSTED; }
     for (unsigned i = 0; i < code - 1; ++i) {
       dst[dst_idx++] = *src++;
     }
 
     if ((src < end) && (code < 0xFF)) {
-      if (++dec_len > dec_max) { return COBS_RET_ERR_EXHAUSTED; }
+      if ((dst_idx + 1) > dec_max) { return COBS_RET_ERR_EXHAUSTED; }
       dst[dst_idx++] = 0;
     }
   }
 
-  *out_dec_len = dec_len;
+  *out_dec_len = dst_idx;
   return COBS_RET_SUCCESS;
 }

--- a/cobs.c
+++ b/cobs.c
@@ -98,23 +98,23 @@ cobs_ret_t cobs_decode(void const *enc,
   if (enc_len < 2) { return COBS_RET_ERR_BAD_ARG; }
 
   cobs_byte_t const *src = (cobs_byte_t const *)enc;
-  cobs_byte_t const *const end = src + enc_len - 1;
-  if (!*src || *end) { return COBS_RET_ERR_BAD_PAYLOAD; }
-
   cobs_byte_t *dst = (cobs_byte_t *)out_dec;
+
+  if (!src[0] || src[enc_len - 1]) { return COBS_RET_ERR_BAD_PAYLOAD; }
+
   unsigned src_idx = 0, dst_idx = 0;
 
-  while (src + src_idx < end) {
+  while (src_idx < (enc_len - 1)) {
     unsigned const code = src[src_idx++];
     if (!code) { return COBS_RET_ERR_BAD_PAYLOAD; }
-    if (src + src_idx + code - 1 > end) { return COBS_RET_ERR_BAD_PAYLOAD; }
+    if ((src_idx + code) > enc_len) { return COBS_RET_ERR_BAD_PAYLOAD; }
 
     if ((dst_idx + code - 1) > dec_max) { return COBS_RET_ERR_EXHAUSTED; }
     for (unsigned i = 0; i < code - 1; ++i) {
       dst[dst_idx++] = src[src_idx++];
     }
 
-    if ((src + src_idx < end) && (code < 0xFF)) {
+    if ((src_idx < (enc_len - 1)) && (code < 0xFF)) {
       if ((dst_idx + 1) > dec_max) { return COBS_RET_ERR_EXHAUSTED; }
       dst[dst_idx++] = 0;
     }

--- a/cobs.c
+++ b/cobs.c
@@ -115,7 +115,7 @@ cobs_ret_t cobs_decode(void const *enc,
     }
 
     if ((src_idx < (enc_len - 1)) && (code < 0xFF)) {
-      if ((dst_idx + 1) > dec_max) { return COBS_RET_ERR_EXHAUSTED; }
+      if (dst_idx >= dec_max) { return COBS_RET_ERR_EXHAUSTED; }
       dst[dst_idx++] = 0;
     }
   }

--- a/cobs.c
+++ b/cobs.c
@@ -97,8 +97,8 @@ cobs_ret_t cobs_decode(void const *enc,
   if (!enc || !out_dec || !out_dec_len) { return COBS_RET_ERR_BAD_ARG; }
   if (enc_len < 2) { return COBS_RET_ERR_BAD_ARG; }
 
-  cobs_byte_t const *src = (cobs_byte_t const *)enc;
-  cobs_byte_t *dst = (cobs_byte_t *)out_dec;
+  cobs_byte_t const *const src = (cobs_byte_t const *)enc;
+  cobs_byte_t *const dst = (cobs_byte_t *)out_dec;
 
   if (!src[0] || src[enc_len - 1]) { return COBS_RET_ERR_BAD_PAYLOAD; }
 


### PR DESCRIPTION
This PR moves the implementation from pointer comparisons to index comparisons, mostly for standards compliance and portability. As discussed with @oreparaz in #25 it's undefined behavior to compare pointers that aren't in the same array or one-past the end. It's always defined to compare unsigned integers.