### PR TITLE
Wikipedia: do in-place `cobs_decode()` in the encoded buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ if (result == COBS_RET_SUCCESS) {
 
 ### Decoding In-Place
 
+There are two ways to decode COBS-encoded data in-place. One is simply by calling `cobs_decode` and pass your buffer to both the `enc` and `out_dec` parameters. Since COBS decoding never needs to revisit decoded bytes, and decoded payloads are always shorter than encoded payloads, this is guaranteed to work.
+
+`cobs_decode_inplace` is also provided and offers byte-layout-parity to `cobs_encode_inplace`. This lets you, for example, decode a payload, change some bytes, and re-encode it all in the same buffer:
+
 Accumulate data from your source until you encounter a COBS frame delimiter byte of `0x00`. Once you've got that, call `cobs_decode_inplace` on that region of a buffer to do an in-place decoding. The zeroth and zero bytes of your payload will be replaced with the `COBS_SENTINEL_VALUE` bytes that, were you _encoding_ in-place, you would have had to place there anyway.
 
 ```

--- a/tests/test_wikipedia.cc
+++ b/tests/test_wikipedia.cc
@@ -43,6 +43,16 @@ void round_trip(byte_vec_t const &decoded, byte_vec_t const &encoded) {
                        &dec_actual_len) == COBS_RET_SUCCESS );
 
   REQUIRE( decoded == byte_vec_t(dec_actual, dec_actual + dec_actual_len) );
+
+  // Additionaly, in-place decode atop enc_actual using cobs_decode.
+
+  REQUIRE( cobs_decode(enc_actual,
+                       enc_actual_len,
+                       enc_actual,
+                       sizeof(enc_actual),
+                       &dec_actual_len) == COBS_RET_SUCCESS );
+
+  REQUIRE( decoded == byte_vec_t(enc_actual, enc_actual + dec_actual_len) );
 }
 }
 


### PR DESCRIPTION
Decoding in-place with `cobs_decode()` works fine since the decoded buffer is always smaller than the encoded buffer, and encoded bytes never need to be revisited once processed.

This PR adds this style of decoding to the wikipedia tests.