### PR TITLE
c++ update, clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,37 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 2
+ContinuationIndentWidth: 4
+PPIndentWidth: 2
+ColumnLimit: 91
+IndentCaseLabels: true
+Cpp11BracedListStyle: false
+IncludeBlocks: Preserve
+
+AlignAfterOpenBracket: Align
+AlignEscapedNewlines: DontAlign
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortLoopsOnASingleLine: true
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AlwaysBreakAfterReturnType: None
+
+BinPackArguments: false
+BinPackParameters: false
+
+BitFieldColonSpacing: Both
+
+InsertTrailingCommas: Wrapped
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+MaxEmptyLinesToKeep: 1
+
+ReflowComments: true
+SpaceAfterCStyleCast: false
+StatementMacros: ['_Pragma']
+---
+Language: Proto
+BasedOnStyle: Google

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-SRCS := tests/test_cobs_encode_max.cc \
+SRCS := tests/cobs_encode_max_c.c \
+		tests/test_cobs_encode_max.cc \
 		tests/test_cobs_encode.cc \
 		tests/test_cobs_encode_inc.cc \
 		tests/test_cobs_encode_inplace.cc \

--- a/cobs.c
+++ b/cobs.c
@@ -4,72 +4,89 @@
 
 typedef unsigned char cobs_byte_t;
 
-cobs_ret_t cobs_encode_inplace(void *buf, unsigned len) {
-  if (!buf || (len < 2)) { return COBS_RET_ERR_BAD_ARG; }
+cobs_ret_t cobs_encode_inplace(void *buf, size_t len) {
+  if (!buf || (len < 2)) {
+    return COBS_RET_ERR_BAD_ARG;
+  }
 
   cobs_byte_t *const src = (cobs_byte_t *)buf;
   if ((src[0] != COBS_ISV) || (src[len - 1] != COBS_ISV)) {
     return COBS_RET_ERR_BAD_PAYLOAD;
   }
 
-  unsigned patch = 0, cur = 1;
+  size_t patch = 0, cur = 1;
   while (cur < len - 1) {
     if (src[cur] == COBS_FRAME_DELIMITER) {
-      unsigned const ofs = cur - patch;
-      if (ofs > 255) { return COBS_RET_ERR_BAD_PAYLOAD; }
+      size_t const ofs = cur - patch;
+      if (ofs > 255) {
+        return COBS_RET_ERR_BAD_PAYLOAD;
+      }
       src[patch] = (cobs_byte_t)ofs;
       patch = cur;
     }
     ++cur;
   }
-  unsigned const ofs = cur - patch;
-  if (ofs > 255) { return COBS_RET_ERR_BAD_PAYLOAD; }
+  size_t const ofs = cur - patch;
+  if (ofs > 255) {
+    return COBS_RET_ERR_BAD_PAYLOAD;
+  }
   src[patch] = (cobs_byte_t)ofs;
   src[cur] = 0;
   return COBS_RET_SUCCESS;
 }
 
-cobs_ret_t cobs_decode_inplace(void *buf, unsigned const len) {
-  if (!buf || (len < 2)) { return COBS_RET_ERR_BAD_ARG; }
+cobs_ret_t cobs_decode_inplace(void *buf, size_t const len) {
+  if (!buf || (len < 2)) {
+    return COBS_RET_ERR_BAD_ARG;
+  }
 
   cobs_byte_t *const src = (cobs_byte_t *)buf;
-  unsigned ofs, cur = 0;
+  size_t ofs, cur = 0;
   while (cur < len && ((ofs = src[cur]) != COBS_FRAME_DELIMITER)) {
     src[cur] = 0;
-    for (unsigned i = 1; i < ofs; ++i) {
-      if (src[cur + i] == 0) { return COBS_RET_ERR_BAD_PAYLOAD; }
+    for (size_t i = 1; i < ofs; ++i) {
+      if (src[cur + i] == 0) {
+        return COBS_RET_ERR_BAD_PAYLOAD;
+      }
     }
     cur += ofs;
   }
 
-  if (cur != len - 1) { return COBS_RET_ERR_BAD_PAYLOAD; }
+  if (cur != len - 1) {
+    return COBS_RET_ERR_BAD_PAYLOAD;
+  }
   src[0] = COBS_ISV;
   src[len - 1] = COBS_ISV;
   return COBS_RET_SUCCESS;
 }
 
 cobs_ret_t cobs_encode(void const *dec,
-                       unsigned dec_len,
+                       size_t dec_len,
                        void *out_enc,
-                       unsigned enc_max,
-                       unsigned *out_enc_len) {
-  if (!out_enc_len) { return COBS_RET_ERR_BAD_ARG; }
+                       size_t enc_max,
+                       size_t *out_enc_len) {
+  if (!out_enc_len) {
+    return COBS_RET_ERR_BAD_ARG;
+  }
 
   cobs_enc_ctx_t ctx;
   cobs_ret_t r;
-  r = cobs_encode_inc_begin(out_enc, enc_max, &ctx);
-  if (r != COBS_RET_SUCCESS) { return r; }
-  r = cobs_encode_inc(&ctx, dec, dec_len);
-  if (r != COBS_RET_SUCCESS) { return r; }
-  r = cobs_encode_inc_end(&ctx, out_enc_len);
-  return r;
+  if ((r = cobs_encode_inc_begin(out_enc, enc_max, &ctx)) != COBS_RET_SUCCESS) {
+    return r;
+  }
+  if ((r = cobs_encode_inc(&ctx, dec, dec_len)) != COBS_RET_SUCCESS) {
+    return r;
+  }
+  return cobs_encode_inc_end(&ctx, out_enc_len);
 }
 
-cobs_ret_t cobs_encode_inc_begin(void *out_enc,
-                                 unsigned enc_max,
-                                 cobs_enc_ctx_t *out_ctx) {
-  if (!out_enc || !out_ctx) { return COBS_RET_ERR_BAD_ARG; }
-  if (enc_max < 2) { return COBS_RET_ERR_BAD_ARG; }
+cobs_ret_t cobs_encode_inc_begin(void *out_enc, size_t enc_max, cobs_enc_ctx_t *out_ctx) {
+  if (!out_enc || !out_ctx) {
+    return COBS_RET_ERR_BAD_ARG;
+  }
+  if (enc_max < 2) {
+    return COBS_RET_ERR_BAD_ARG;
+  }
 
   out_ctx->dst = out_enc;
   out_ctx->dst_max = enc_max;
@@ -80,25 +97,31 @@ cobs_ret_t cobs_encode_inc_begin(void *out_enc,
   return COBS_RET_SUCCESS;
 }
 
-cobs_ret_t cobs_encode_inc(cobs_enc_ctx_t *ctx,
-                           void const *dec,
-                           unsigned dec_len) {
-  if (!ctx || !dec) { return COBS_RET_ERR_BAD_ARG; }
-  unsigned dst_idx = ctx->cur;
-  unsigned const enc_max = ctx->dst_max;
-  if ((enc_max - dst_idx) < dec_len) { return COBS_RET_ERR_EXHAUSTED; }
-  if (!dec_len) { return COBS_RET_SUCCESS; }
+cobs_ret_t cobs_encode_inc(cobs_enc_ctx_t *ctx, void const *dec, size_t dec_len) {
+  if (!ctx || !dec) {
+    return COBS_RET_ERR_BAD_ARG;
+  }
+  size_t dst_idx = ctx->cur;
+  size_t const enc_max = ctx->dst_max;
+  if ((enc_max - dst_idx) < dec_len) {
+    return COBS_RET_ERR_EXHAUSTED;
+  }
+  if (!dec_len) {
+    return COBS_RET_SUCCESS;
+  }
 
-  unsigned dst_code_idx = ctx->code_idx;
+  size_t dst_code_idx = ctx->code_idx;
   unsigned code = ctx->code;
   int need_advance = ctx->need_advance;
 
   cobs_byte_t const *const src = (cobs_byte_t const *)dec;
   cobs_byte_t *const dst = (cobs_byte_t *)ctx->dst;
-  unsigned src_idx = 0;
+  size_t src_idx = 0;
 
   if (need_advance) {
-    if (++dst_idx >= enc_max) { return COBS_RET_ERR_EXHAUSTED; }
+    if (++dst_idx >= enc_max) {
+      return COBS_RET_ERR_EXHAUSTED;
+    }
     need_advance = 0;
   }
 
@@ -106,7 +129,9 @@ cobs_ret_t cobs_encode_inc(cobs_enc_ctx_t *ctx,
     cobs_byte_t const byte = src[src_idx];
     if (byte) {
       dst[dst_idx] = byte;
-      if (++dst_idx >= enc_max) { return COBS_RET_ERR_EXHAUSTED; }
+      if (++dst_idx >= enc_max) {
+        return COBS_RET_ERR_EXHAUSTED;
+      }
       ++code;
     }
 
@@ -116,7 +141,9 @@ cobs_ret_t cobs_encode_inc(cobs_enc_ctx_t *ctx,
       code = 1;
 
       if ((byte == 0) || dec_len) {
-        if (++dst_idx >= enc_max) { return COBS_RET_ERR_EXHAUSTED; }
+        if (++dst_idx >= enc_max) {
+          return COBS_RET_ERR_EXHAUSTED;
+        }
       } else {
         need_advance = !dec_len;
       }
@@ -131,11 +158,13 @@ cobs_ret_t cobs_encode_inc(cobs_enc_ctx_t *ctx,
   return COBS_RET_SUCCESS;
 }
 
-cobs_ret_t cobs_encode_inc_end(cobs_enc_ctx_t *ctx, unsigned *out_enc_len) {
-  if (!ctx || !out_enc_len) { return COBS_RET_ERR_BAD_ARG; }
+cobs_ret_t cobs_encode_inc_end(cobs_enc_ctx_t *ctx, size_t *out_enc_len) {
+  if (!ctx || !out_enc_len) {
+    return COBS_RET_ERR_BAD_ARG;
+  }
 
   cobs_byte_t *const dst = (cobs_byte_t *)ctx->dst;
-  unsigned cur = ctx->cur;
+  size_t cur = ctx->cur;
   dst[ctx->code_idx] = (cobs_byte_t)ctx->code;
   dst[cur++] = COBS_FRAME_DELIMITER;
   *out_enc_len = cur;
@@ -143,12 +172,16 @@ cobs_ret_t cobs_encode_inc_end(cobs_enc_ctx_t *ctx, unsigned *out_enc_len) {
 }
 
 cobs_ret_t cobs_decode(void const *enc,
-                       unsigned enc_len,
+                       size_t enc_len,
                        void *out_dec,
-                       unsigned dec_max,
-                       unsigned *out_dec_len) {
-  if (!enc || !out_dec || !out_dec_len) { return COBS_RET_ERR_BAD_ARG; }
-  if (enc_len < 2) { return COBS_RET_ERR_BAD_ARG; }
+                       size_t dec_max,
+                       size_t *out_dec_len) {
+  if (!enc || !out_dec || !out_dec_len) {
+    return COBS_RET_ERR_BAD_ARG;
+  }
+  if (enc_len < 2) {
+    return COBS_RET_ERR_BAD_ARG;
+  }
 
   cobs_byte_t const *const src = (cobs_byte_t const *)enc;
   cobs_byte_t *const dst = (cobs_byte_t *)out_dec;
@@ -157,21 +190,31 @@ cobs_ret_t cobs_decode(void const *enc,
     return COBS_RET_ERR_BAD_PAYLOAD;
   }
 
-  unsigned src_idx = 0, dst_idx = 0;
+  size_t src_idx = 0, dst_idx = 0;
 
   while (src_idx < (enc_len - 1)) {
     unsigned const code = src[src_idx++];
-    if (!code) { return COBS_RET_ERR_BAD_PAYLOAD; }
-    if ((src_idx + code) > enc_len) { return COBS_RET_ERR_BAD_PAYLOAD; }
+    if (!code) {
+      return COBS_RET_ERR_BAD_PAYLOAD;
+    }
+    if ((src_idx + code) > enc_len) {
+      return COBS_RET_ERR_BAD_PAYLOAD;
+    }
 
-    if ((dst_idx + code - 1) > dec_max) { return COBS_RET_ERR_EXHAUSTED; }
-    for (unsigned i = 0; i < code - 1; ++i) {
-      if (src[src_idx] == 0) { return COBS_RET_ERR_BAD_PAYLOAD; }
+    if ((dst_idx + code - 1) > dec_max) {
+      return COBS_RET_ERR_EXHAUSTED;
+    }
+    for (size_t i = 0; i < code - 1; ++i) {
+      if (src[src_idx] == 0) {
+        return COBS_RET_ERR_BAD_PAYLOAD;
+      }
       dst[dst_idx++] = src[src_idx++];
     }
 
     if ((src_idx < (enc_len - 1)) && (code < 0xFF)) {
-      if (dst_idx >= dec_max) { return COBS_RET_ERR_EXHAUSTED; }
+      if (dst_idx >= dec_max) {
+        return COBS_RET_ERR_EXHAUSTED;
+      }
       dst[dst_idx++] = 0;
     }
   }

--- a/cobs.h
+++ b/cobs.h
@@ -30,13 +30,18 @@ enum {
 // COBS_ENCODE_MAX
 //
 // Returns the maximum possible size in bytes of the buffer required to encode a buffer of
-// length |dec_len|. Cannot fail. Defined as a macro to facilitate compile-time sizing of
-// buffers.
-//
-// Note: DECODED_LEN is evaluated multiple times; don't call with mutating expressions!
+// length |dec_len|. Cannot fail. Defined as macro/constexpr to facilitate compile-time
+// sizing of buffers.
+#ifdef __cplusplus
+inline constexpr size_t COBS_ENCODE_MAX(size_t DECODED_LEN) {
+  return 1 + DECODED_LEN + ((DECODED_LEN + 253) / 254) + (DECODED_LEN == 0);
+}
+#else
+// In C, DECODED_LEN is evaluated multiple times; don't call with mutating expressions!
 // e.g. Don't do "COBS_ENCODE_MAX(i++)".
 #define COBS_ENCODE_MAX(DECODED_LEN) \
   (1 + (DECODED_LEN) + (((DECODED_LEN) + 253) / 254) + ((DECODED_LEN) == 0))
+#endif
 
 // cobs_encode_inplace
 //

--- a/cobs.h
+++ b/cobs.h
@@ -171,29 +171,6 @@ cobs_ret_t cobs_encode_inc(cobs_enc_ctx_t *ctx, void const *dec_src, size_t dec_
 // If null pointers are provided, the function returns COBS_RET_ERR_BAD_ARG.
 cobs_ret_t cobs_encode_inc_end(cobs_enc_ctx_t *ctx, size_t *out_enc_len);
 
-// Incremental decoding API
-
-typedef struct cobs_dec_ctx {
-  size_t read_cursor;
-  unsigned code;
-} cobs_dec_ctx_t;
-
-typedef struct cobs_dec_args {
-  // inputs
-  void const *src;  // pointer to current position of encoded payload
-  void *dst;        // pointer to decoded buffer.
-  size_t src_max;   // length of the |src| input buffer.
-  size_t dst_max;   // length of the |dst| output buffer.
-
-  // outputs
-  size_t src_len;        // how many bytes of |src| were consumed in this call.
-  size_t dst_len;        // how many bytes were decoded into |dst|.
-  bool decode_complete;  // whether a full COBS decoding was completed.
-} cobs_dec_args_t;
-
-cobs_ret_t cobs_decode_inc_begin(cobs_dec_ctx_t *ctx);
-cobs_ret_t cobs_decode_inc(cobs_dec_ctx_t *ctx, cobs_dec_args_t *args);
-
 #ifdef __cplusplus
 }
 #endif

--- a/cobs.h
+++ b/cobs.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum {
   COBS_RET_SUCCESS = 0,
   COBS_RET_ERR_BAD_ARG,
@@ -7,11 +14,10 @@ typedef enum {
   COBS_RET_ERR_EXHAUSTED
 } cobs_ret_t;
 
-
 enum {
-  // All COBS frames end with this value. If you're scanning a data source
-  // for frame delimiters, the presence of this zero byte indicates the
-  // completion of a frame.
+  // All COBS frames end with this value. If you're scanning a data source for
+  // frame delimiters, the presence of this zero byte indicates the completion
+  // of a frame.
   COBS_FRAME_DELIMITER = 0x00,
 
   // In-place encoding mandatory placeholder byte values.
@@ -21,166 +27,167 @@ enum {
   COBS_INPLACE_SAFE_BUFFER_SIZE = 256
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 // COBS_ENCODE_MAX
 //
-// Returns the maximum possible size in bytes of the buffer required to encode
-// a buffer of length |dec_len|. Cannot fail. Defined as a macro to facilitate
-// compile-time sizing of buffers.
+// Returns the maximum possible size in bytes of the buffer required to encode a buffer of
+// length |dec_len|. Cannot fail. Defined as a macro to facilitate compile-time sizing of
+// buffers.
 //
-// Note: DECODED_LEN is evaluated multiple times; don't call with mutating
-// expressions! e.g. Don't do "COBS_ENCODE_MAX(i++)".
+// Note: DECODED_LEN is evaluated multiple times; don't call with mutating expressions!
+// e.g. Don't do "COBS_ENCODE_MAX(i++)".
 #define COBS_ENCODE_MAX(DECODED_LEN) \
   (1 + (DECODED_LEN) + (((DECODED_LEN) + 253) / 254) + ((DECODED_LEN) == 0))
 
-
 // cobs_encode_inplace
 //
-// Encode in-place the contents of the provided buffer |buf| of length |len|.
-// Returns COBS_RET_SUCCESS on successful encoding.
+// Encode in-place the contents of the provided buffer |buf| of length |len|. Returns
+// COBS_RET_SUCCESS on successful encoding.
 //
-// Because encoding adds leading and trailing bytes, your buffer must reserve
-// bytes 0 and len-1 for the encoding. If the first and last bytes of |buf|
-// are not set to COBS_INPLACE_SENTINEL_VALUE, the function will fail with
-// COBS_RET_ERR_BAD_PAYLOAD.
+// Because encoding adds leading and trailing bytes, your buffer must reserve bytes 0 and
+// len-1 for the encoding. If the first and last bytes of |buf| are not set to
+// COBS_INPLACE_SENTINEL_VALUE, the function will fail with COBS_RET_ERR_BAD_PAYLOAD.
 //
-// If a null pointer or invalid length are provided, the function will fail
-// with COBS_RET_ERR_BAD_ARG.
+// If a null pointer or invalid length are provided, the function will fail with
+// COBS_RET_ERR_BAD_ARG.
 //
-// If |len| is less than or equal to COBS_INPLACE_SAFE_BUFFER_SIZE, the
-// contents of |buf| will never cause encoding to fail. If |len| is larger
-// than COBS_INPLACE_SAFE_BUFFER_SIZE, encoding can possibly fail with
-// COBS_RET_ERR_BAD_PAYLOAD if there are more than 254 bytes between zeros.
+// If |len| is less than or equal to COBS_INPLACE_SAFE_BUFFER_SIZE, the contents of |buf|
+// will never cause encoding to fail. If |len| is larger than
+// COBS_INPLACE_SAFE_BUFFER_SIZE, encoding can possibly fail with COBS_RET_ERR_BAD_PAYLOAD
+// if there are more than 254 bytes between zeros.
 //
-// If the function returns COBS_RET_ERR_BAD_PAYLOAD, the contents of |buf| are
-// left indeterminate and must not be relied on to be fully encoded or decoded.
-cobs_ret_t cobs_encode_inplace(void *buf, unsigned len);
-
+// If the function returns COBS_RET_ERR_BAD_PAYLOAD, the contents of |buf| are left
+// indeterminate and must not be relied on to be fully encoded or decoded.
+cobs_ret_t cobs_encode_inplace(void *buf, size_t len);
 
 // cobs_decode_inplace
 //
 // Decode in-place the contents of the provided buffer |buf| of length |len|.
 // Returns COBS_RET_SUCCESS on successful decoding.
 //
-// Because decoding is in-place, the first and last bytes of |buf| will be set
-// to the value COBS_INPLACE_SENTINEL_VALUE if decoding succeeds. The decoded
-// contents are stored in the inclusive span defined by buf[1] and buf[len-2].
+// Because decoding is in-place, the first and last bytes of |buf| will be set to the value
+// COBS_INPLACE_SENTINEL_VALUE if decoding succeeds. The decoded contents are stored in the
+// inclusive span defined by buf[1] and buf[len-2].
 //
-// If a null pointer or invalid length are provided, the function will fail
-// with COBS_RET_ERR_BAD_ARG.
+// If a null pointer or invalid length are provided, the function will fail with
+// COBS_RET_ERR_BAD_ARG.
 //
-// If the encoded buffer contains any code bytes that exceed |len|, the
-// function will fail with COBS_RET_ERR_BAD_PAYLOAD. If the buffer starts
-// with a 0 byte, or ends in a nonzero byte, the function will fail with
-// COBS_RET_ERR_BAD_PAYLOAD.
+// If the encoded buffer contains any code bytes that exceed |len|, the function will fail
+// with COBS_RET_ERR_BAD_PAYLOAD. If the buffer starts with a 0 byte, or ends in a nonzero
+// byte, the function will fail with COBS_RET_ERR_BAD_PAYLOAD.
 //
-// If the function returns COBS_RET_ERR_BAD_PAYLOAD, the contents of |buf| are
-// left indeterminate and must not be relied on to be fully encoded or decoded.
-cobs_ret_t cobs_decode_inplace(void *buf, unsigned len);
-
+// If the function returns COBS_RET_ERR_BAD_PAYLOAD, the contents of |buf| are left
+// indeterminate and must not be relied on to be fully encoded or decoded.
+cobs_ret_t cobs_decode_inplace(void *buf, size_t len);
 
 // cobs_decode
 //
-// Decode |enc_len| encoded bytes from |enc| into |out_dec|, storing the decoded
-// length in |out_dec_len|. Returns COBS_RET_SUCCESS on successful decoding.
+// Decode |enc_len| encoded bytes from |enc| into |out_dec|, storing the decoded length in
+// |out_dec_len|. Returns COBS_RET_SUCCESS on successful decoding.
 //
-// If any of the input pointers are null, or if any of the lengths are invalid,
-// the function will fail with COBS_RET_ERR_BAD_ARG.
+// If any of the input pointers are null, or if any of the lengths are invalid, the
+// function will fail with COBS_RET_ERR_BAD_ARG.
 //
-// If |enc| starts with a 0 byte, or does not end with a 0 byte, the function
-// will fail with COBS_RET_ERR_BAD_PAYLOAD.
+// If |enc| starts with a 0 byte, or does not end with a 0 byte, the function will fail
+// with COBS_RET_ERR_BAD_PAYLOAD.
 //
 // If the decoding exceeds |dec_max| bytes, the function will fail with
 // COBS_RET_ERR_EXHAUSTED.
 cobs_ret_t cobs_decode(void const *enc,
-                       unsigned enc_len,
+                       size_t enc_len,
                        void *out_dec,
-                       unsigned dec_max,
-                       unsigned *out_dec_len);
-
+                       size_t dec_max,
+                       size_t *out_dec_len);
 
 // cobs_encode
 //
-// Encode |dec_len| decoded bytes from |dec| into |out_enc|, storing the encoded
-// length in |out_enc_len|. Returns COBS_RET_SUCCESS on successful encoding.
+// Encode |dec_len| decoded bytes from |dec| into |out_enc|, storing the encoded length in
+// |out_enc_len|. Returns COBS_RET_SUCCESS on successful encoding.
 //
-// If any of the input pointers are null, or if any of the lengths are invalid,
-// the function will fail with COBS_RET_ERR_BAD_ARG.
+// If any of the input pointers are null, or if any of the lengths are invalid, the
+// function will fail with COBS_RET_ERR_BAD_ARG.
 //
 // If the encoding exceeds |enc_max| bytes, the function will fail with
 // COBS_RET_ERR_EXHAUSTED.
 cobs_ret_t cobs_encode(void const *dec,
-                       unsigned dec_len,
+                       size_t dec_len,
                        void *out_enc,
-                       unsigned enc_max,
-                       unsigned *out_enc_len);
-
+                       size_t enc_max,
+                       size_t *out_enc_len);
 
 // Incremental encoding API
 
 typedef struct cobs_enc_ctx {
   void *dst;
-  unsigned dst_max;
-  unsigned cur;
-  unsigned code_idx;
+  size_t dst_max;
+  size_t cur;
+  size_t code_idx;
   unsigned code;
   int need_advance;
 } cobs_enc_ctx_t;
 
-
 // cobs_encode_inc_begin
 //
-// Begin an incremental encoding of data into |out_enc|. The intermediate
-// encoding state is stored in |out_ctx|, which can then be passed into
-// calls to cobs_encode_inc. Returns COBS_RET_SUCCESS if |out_ctx| can be
-// used in future calls to cobs_encode_inc.
+// Begin an incremental encoding of data into |out_enc|. The intermediate encoding state is
+// stored in |out_ctx|, which can then be passed into calls to cobs_encode_inc. Returns
+// COBS_RET_SUCCESS if |out_ctx| can be used in future calls to cobs_encode_inc.
 //
-// If |out_enc| or |out_ctx| are null, or if |enc_max| is not large enough to
-// hold the smallest possible encoding, the function will return
-// COBS_RET_ERR_BAD_ARG.
-cobs_ret_t cobs_encode_inc_begin(void *out_enc,
-                                 unsigned enc_max,
-                                 cobs_enc_ctx_t *out_ctx);
-
+// If |out_enc| or |out_ctx| are null, or if |enc_max| is not large enough to hold the
+// smallest possible encoding, the function will return COBS_RET_ERR_BAD_ARG.
+cobs_ret_t cobs_encode_inc_begin(void *out_enc, size_t enc_max, cobs_enc_ctx_t *out_ctx);
 
 // cobs_encode_inc
 //
-// Continue an encoding in progress with the new |dec| buffer of length |dec_len|.
-// Encodes |dec_len| decoded bytes from |dec| into the buffer that |ctx| was
-// initialized with in cobs_encode_inc_begin.
+// Continue an encoding in progress with the new |dec| buffer of length |dec_len|. Encodes
+// |dec_len| decoded bytes from |dec| into the buffer that |ctx| was initialized with in
+// cobs_encode_inc_begin.
 //
-// If any of the input pointers are null, or |dec_len| is zero, the function
-// will fail with COBS_RET_ERR_BAD_ARG.
+// If any of the input pointers are null, or |dec_len| is zero, the function will fail with
+// COBS_RET_ERR_BAD_ARG.
 //
-// If the contents pointed to by |dec| can not be encoded in the remaining
-// available buffer space, the function returns COBS_RET_ERR_EXHAUSTED. In
-// this case, |ctx| remains unchanged and incremental encoding can be attempted
-// again with different data, or finished with cobs_encode_inc_end.
+// If the contents pointed to by |dec| can not be encoded in the remaining available buffer
+// space, the function returns COBS_RET_ERR_EXHAUSTED. In this case, |ctx| remains
+// unchanged and incremental encoding can be attempted again with different data, or
+// finished with cobs_encode_inc_end.
 //
 // If the contents of |dec| are successfully encoded, the function returns
 // COBS_RET_SUCCESS.
-cobs_ret_t cobs_encode_inc(cobs_enc_ctx_t *ctx,
-                           void const *dec,
-                           unsigned dec_len);
-
+cobs_ret_t cobs_encode_inc(cobs_enc_ctx_t *ctx, void const *dec_src, size_t dec_len);
 
 // cobs_encode_inc_end
 //
 // Finish an incremental encoding by writing the final code and delimiter.
-// Returns COBS_RET_SUCCESS on success, and no further calls to
-// cobs_encode_inc or cobs_encode_inc_end can be safely made until |ctx|
-// is re-initialized via a new call to cobs_encode_inc_begin.
+// Returns COBS_RET_SUCCESS on success, and no further calls to cobs_encode_inc or
+// cobs_encode_inc_end can be safely made until |ctx| is re-initialized via a new call to
+// cobs_encode_inc_begin.
 //
-// The final encoded length is written to |out_enc_len|, and the buffer
-// passed to cobs_encode_inc_begin holds the full COBS-encoded frame.
+// The final encoded length is written to |out_enc_len|, and the buffer passed to
+// cobs_encode_inc_begin holds the full COBS-encoded frame.
 //
 // If null pointers are provided, the function returns COBS_RET_ERR_BAD_ARG.
-cobs_ret_t cobs_encode_inc_end(cobs_enc_ctx_t *ctx, unsigned *out_enc_len);
+cobs_ret_t cobs_encode_inc_end(cobs_enc_ctx_t *ctx, size_t *out_enc_len);
 
+// Incremental decoding API
+
+typedef struct cobs_dec_ctx {
+  size_t read_cursor;
+  unsigned code;
+} cobs_dec_ctx_t;
+
+typedef struct cobs_dec_args {
+  // inputs
+  void const *src;  // pointer to current position of encoded payload
+  void *dst;        // pointer to decoded buffer.
+  size_t src_max;   // length of the |src| input buffer.
+  size_t dst_max;   // length of the |dst| output buffer.
+
+  // outputs
+  size_t src_len;        // how many bytes of |src| were consumed in this call.
+  size_t dst_len;        // how many bytes were decoded into |dst|.
+  bool decode_complete;  // whether a full COBS decoding was completed.
+} cobs_dec_args_t;
+
+cobs_ret_t cobs_decode_inc_begin(cobs_dec_ctx_t *ctx);
+cobs_ret_t cobs_decode_inc(cobs_dec_ctx_t *ctx, cobs_dec_args_t *args);
 
 #ifdef __cplusplus
 }

--- a/make-win.bat
+++ b/make-win.bat
@@ -1,5 +1,6 @@
 cl.exe /W4 /WX /MP /EHsc ^
     cobs.c ^
+    tests/cobs_encode_max_c.c ^
     tests/test_cobs_decode.cc ^
     tests/test_cobs_decode_inplace.cc ^
     tests/test_cobs_encode_max.cc ^

--- a/tests/byte_vec.h
+++ b/tests/byte_vec.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <vector>
 
 using byte_t = unsigned char;

--- a/tests/cobs_encode_max_c.c
+++ b/tests/cobs_encode_max_c.c
@@ -1,0 +1,9 @@
+#include "cobs_encode_max_c.h"
+
+#include "../cobs.h"
+
+enum { WORKS_AT_COMPILE_TIME = COBS_ENCODE_MAX(123) };
+
+size_t cobs_encode_max_c(size_t decoded_len) {
+  return COBS_ENCODE_MAX(decoded_len);
+}

--- a/tests/cobs_encode_max_c.h
+++ b/tests/cobs_encode_max_c.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+size_t cobs_encode_max_c(size_t decoded_len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/doctest.h
+++ b/tests/doctest.h
@@ -4,7 +4,7 @@
 //
 // doctest.h - the lightest feature-rich C++ single-header testing framework for unit tests and TDD
 //
-// Copyright (c) 2016-2021 Viktor Kirilov
+// Copyright (c) 2016-2023 Viktor Kirilov
 //
 // Distributed under the MIT Software License
 // See accompanying file LICENSE.txt or copy at
@@ -48,7 +48,7 @@
 
 #define DOCTEST_VERSION_MAJOR 2
 #define DOCTEST_VERSION_MINOR 4
-#define DOCTEST_VERSION_PATCH 9
+#define DOCTEST_VERSION_PATCH 11
 
 // util we need here
 #define DOCTEST_TOSTR_IMPL(x) #x
@@ -85,12 +85,15 @@
     DOCTEST_COMPILER(_MSC_VER / 100, (_MSC_FULL_VER / 100000) % 100, _MSC_FULL_VER % 100000)
 #endif // MSVC
 #endif // MSVC
-#if defined(__clang__) && defined(__clang_minor__)
+#if defined(__clang__) && defined(__clang_minor__) && defined(__clang_patchlevel__)
 #define DOCTEST_CLANG DOCTEST_COMPILER(__clang_major__, __clang_minor__, __clang_patchlevel__)
 #elif defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__) &&              \
         !defined(__INTEL_COMPILER)
 #define DOCTEST_GCC DOCTEST_COMPILER(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
 #endif // GCC
+#if defined(__INTEL_COMPILER)
+#define DOCTEST_ICC DOCTEST_COMPILER(__INTEL_COMPILER / 100, __INTEL_COMPILER % 100, 0)
+#endif // ICC
 
 #ifndef DOCTEST_MSVC
 #define DOCTEST_MSVC 0
@@ -101,12 +104,15 @@
 #ifndef DOCTEST_GCC
 #define DOCTEST_GCC 0
 #endif // DOCTEST_GCC
+#ifndef DOCTEST_ICC
+#define DOCTEST_ICC 0
+#endif // DOCTEST_ICC
 
 // =================================================================================================
 // == COMPILER WARNINGS HELPERS ====================================================================
 // =================================================================================================
 
-#if DOCTEST_CLANG
+#if DOCTEST_CLANG && !DOCTEST_ICC
 #define DOCTEST_PRAGMA_TO_STR(x) _Pragma(#x)
 #define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH _Pragma("clang diagnostic push")
 #define DOCTEST_CLANG_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(clang diagnostic ignored w)
@@ -152,7 +158,7 @@
 // =================================================================================================
 
 // both the header and the implementation suppress all of these,
-// so it only makes sense to aggregrate them like so
+// so it only makes sense to aggregate them like so
 #define DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                      \
     DOCTEST_CLANG_SUPPRESS_WARNING_PUSH                                                            \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")                                            \
@@ -178,7 +184,7 @@
     DOCTEST_MSVC_SUPPRESS_WARNING(4571) /* SEH related */                                          \
     DOCTEST_MSVC_SUPPRESS_WARNING(4710) /* function not inlined */                                 \
     DOCTEST_MSVC_SUPPRESS_WARNING(4711) /* function selected for inline expansion*/                \
-    /* */                                                                                          \
+    /* common ones */                                                                              \
     DOCTEST_MSVC_SUPPRESS_WARNING(4616) /* invalid compiler warning */                             \
     DOCTEST_MSVC_SUPPRESS_WARNING(4619) /* invalid compiler warning */                             \
     DOCTEST_MSVC_SUPPRESS_WARNING(4996) /* The compiler encountered a deprecated declaration */    \
@@ -192,6 +198,7 @@
     DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */              \
     DOCTEST_MSVC_SUPPRESS_WARNING(4640) /* construction of local static object not thread-safe */  \
     DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                   \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5264) /* 'variable-name': 'const' variable is not used */        \
     /* static analysis */                                                                          \
     DOCTEST_MSVC_SUPPRESS_WARNING(26439) /* Function may not throw. Declare it 'noexcept' */       \
     DOCTEST_MSVC_SUPPRESS_WARNING(26495) /* Always initialize a member variable */                 \
@@ -236,7 +243,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4623) // default constructor was implicitly define
     DOCTEST_MSVC_SUPPRESS_WARNING(5039) /* pointer to pot. throwing function passed to extern C */ \
     DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                   \
     DOCTEST_MSVC_SUPPRESS_WARNING(5105) /* macro producing 'defined' has undefined behavior */     \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4738) /* storing float result in memory, loss of performance */
+    DOCTEST_MSVC_SUPPRESS_WARNING(4738) /* storing float result in memory, loss of performance */  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5262) /* implicit fall-through */
 
 #define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
@@ -352,6 +360,12 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4623) // default constructor was implicitly define
 #define DOCTEST_ALIGNMENT(x) __attribute__((aligned(x)))
 #endif
 
+#ifdef DOCTEST_CONFIG_NO_CONTRADICTING_INLINE
+#define DOCTEST_INLINE_NOINLINE inline
+#else
+#define DOCTEST_INLINE_NOINLINE inline DOCTEST_NOINLINE
+#endif
+
 #ifndef DOCTEST_NORETURN
 #if DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
 #define DOCTEST_NORETURN
@@ -377,6 +391,14 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4623) // default constructor was implicitly define
 #define DOCTEST_CONSTEXPR_FUNC constexpr
 #endif // DOCTEST_MSVC
 #endif // DOCTEST_CONSTEXPR
+
+#ifndef DOCTEST_NO_SANITIZE_INTEGER
+#if DOCTEST_CLANG >= DOCTEST_COMPILER(3, 7, 0)
+#define DOCTEST_NO_SANITIZE_INTEGER __attribute__((no_sanitize("integer")))
+#else
+#define DOCTEST_NO_SANITIZE_INTEGER
+#endif
+#endif // DOCTEST_NO_SANITIZE_INTEGER
 
 // =================================================================================================
 // == FEATURE DETECTION END ========================================================================
@@ -475,12 +497,13 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 // https://github.com/doctest/doctest/issues/356
 #if DOCTEST_CLANG
 #include <ciso646>
+#endif // clang
+
 #ifdef _LIBCPP_VERSION
 #ifndef DOCTEST_CONFIG_USE_STD_HEADERS
 #define DOCTEST_CONFIG_USE_STD_HEADERS
 #endif
 #endif // _LIBCPP_VERSION
-#endif // clang
 
 #ifdef DOCTEST_CONFIG_USE_STD_HEADERS
 #ifndef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
@@ -970,7 +993,7 @@ namespace detail {
     struct deferred_false : types::false_type { };
 
 // MSVS 2015 :(
-#if defined(_MSC_VER) && _MSC_VER <= 1900
+#if !DOCTEST_CLANG && defined(_MSC_VER) && _MSC_VER <= 1900
     template <typename T, typename = void>
     struct has_global_insertion_operator : types::false_type { };
 
@@ -1000,8 +1023,13 @@ namespace detail {
     struct has_insertion_operator : types::false_type { };
 #endif
 
-template <typename T>
-struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+    template <typename T>
+    struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+
+    template <typename T>
+    struct should_stringify_as_underlying_type {
+        static DOCTEST_CONSTEXPR bool value = detail::types::is_enum<T>::value && !doctest::detail::has_insertion_operator<T>::value;
+    };
 
     DOCTEST_INTERFACE std::ostream* tlssPush();
     DOCTEST_INTERFACE String tlssPop();
@@ -1063,7 +1091,7 @@ struct StringMaker : public detail::StringMakerBase<
 
 template <typename T>
 String toString() {
-#if DOCTEST_MSVC >= 0 && DOCTEST_CLANG == 0 && DOCTEST_GCC == 0
+#if DOCTEST_CLANG == 0 && DOCTEST_GCC == 0 && DOCTEST_ICC == 0
     String ret = __FUNCSIG__; // class doctest::String __cdecl doctest::toString<TYPE>(void)
     String::size_type beginPos = ret.find('<');
     return ret.substr(beginPos + 1, ret.size() - beginPos - static_cast<String::size_type>(sizeof(">(void)")));
@@ -1074,7 +1102,7 @@ String toString() {
 #endif
 }
 
-template <typename T, typename detail::types::enable_if<!detail::types::is_enum<T>::value, bool>::type = true>
+template <typename T, typename detail::types::enable_if<!detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
 String toString(const DOCTEST_REF_WRAP(T) value) {
     return StringMaker<T>::convert(value);
 }
@@ -1110,7 +1138,7 @@ DOCTEST_INTERFACE String toString(long unsigned in);
 DOCTEST_INTERFACE String toString(long long in);
 DOCTEST_INTERFACE String toString(long long unsigned in);
 
-template <typename T, typename detail::types::enable_if<detail::types::is_enum<T>::value, bool>::type = true>
+template <typename T, typename detail::types::enable_if<detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
 String toString(const DOCTEST_REF_WRAP(T) value) {
     using UT = typename detail::types::underlying_type<T>::type;
     return (DOCTEST_STRINGIFY(static_cast<UT>(value)));
@@ -1162,8 +1190,18 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     template <typename T>
     struct filldata<T*> {
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
         static void fill(std::ostream* stream, const T* in) {
-            filldata<const void*>::fill(stream, in);
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
+            filldata<const void*>::fill(stream,
+#if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
+                reinterpret_cast<const void*>(in)
+#else
+                *reinterpret_cast<const void* const*>(&in)
+#endif
+            );
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
         }
     };
 }
@@ -1275,9 +1313,9 @@ namespace detail {
     template<class T, unsigned N>   struct decay_array<T[N]> { using type = T*; };
     template<class T>               struct decay_array<T[]>  { using type = T*; };
 
-    template<class T>   struct not_char_pointer              { static DOCTEST_CONSTEXPR value = 1; };
-    template<>          struct not_char_pointer<char*>       { static DOCTEST_CONSTEXPR value = 0; };
-    template<>          struct not_char_pointer<const char*> { static DOCTEST_CONSTEXPR value = 0; };
+    template<class T>   struct not_char_pointer              { static DOCTEST_CONSTEXPR int value = 1; };
+    template<>          struct not_char_pointer<char*>       { static DOCTEST_CONSTEXPR int value = 0; };
+    template<>          struct not_char_pointer<const char*> { static DOCTEST_CONSTEXPR int value = 0; };
 
     template<class T> struct can_use_op : public not_char_pointer<typename decay_array<T>::type> {};
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
@@ -1326,7 +1364,11 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
 // If not it doesn't find the operator or if the operator at global scope is defined after
 // this template, the template won't be instantiated due to SFINAE. Once the template is not
 // instantiated it can look for global operator using normal conversions.
+#ifdef __NVCC__
+#define SFINAE_OP(ret,op) ret
+#else
 #define SFINAE_OP(ret,op) decltype((void)(doctest::detail::declval<L>() op doctest::detail::declval<R>()),ret{})
+#endif
 
 #define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
     template <typename R>                                                                          \
@@ -2129,13 +2171,13 @@ int registerReporter(const char* name, int priority, bool isReporter) {
         {                                                                                          \
             void f();                                                                              \
         };                                                                                         \
-        static inline DOCTEST_NOINLINE void func() {                                               \
+        static DOCTEST_INLINE_NOINLINE void func() {                                               \
             der v;                                                                                 \
             v.f();                                                                                 \
         }                                                                                          \
         DOCTEST_REGISTER_FUNCTION(DOCTEST_EMPTY, func, decorators)                                 \
     }                                                                                              \
-    inline DOCTEST_NOINLINE void der::f() // NOLINT(misc-definitions-in-headers)
+    DOCTEST_INLINE_NOINLINE void der::f() // NOLINT(misc-definitions-in-headers)
 
 #define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators)                                        \
     static void f();                                                                               \
@@ -3119,7 +3161,9 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <utility>
 #include <fstream>
 #include <sstream>
+#ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
 #include <iostream>
+#endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
 #include <algorithm>
 #include <iomanip>
 #include <vector>
@@ -3156,9 +3200,11 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 // defines for a leaner windows.h
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#define DOCTEST_UNDEF_WIN32_LEAN_AND_MEAN
 #endif // WIN32_LEAN_AND_MEAN
 #ifndef NOMINMAX
 #define NOMINMAX
+#define DOCTEST_UNDEF_NOMINMAX
 #endif // NOMINMAX
 
 // not sure what AfxWin.h is for - here I do what Catch does
@@ -3239,8 +3285,14 @@ namespace {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
         throw e;
 #else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+#ifdef DOCTEST_CONFIG_HANDLE_EXCEPTION
+        DOCTEST_CONFIG_HANDLE_EXCEPTION(e);
+#else // DOCTEST_CONFIG_HANDLE_EXCEPTION
+#ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
         std::cerr << "doctest will terminate because it needed to throw an exception.\n"
                   << "The message was: " << e.what() << '\n';
+#endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+#endif // DOCTEST_CONFIG_HANDLE_EXCEPTION
         std::terminate();
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
     }
@@ -3315,7 +3367,7 @@ namespace detail {
 
 namespace timer_large_integer
 {
-    
+
 #if defined(DOCTEST_PLATFORM_WINDOWS)
     using type = ULONGLONG;
 #else // DOCTEST_PLATFORM_WINDOWS
@@ -3777,7 +3829,7 @@ namespace Color {
 
 // clang-format off
 const char* assertString(assertType::Enum at) {
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4061) // enum 'x' in switch of enum 'y' is not explicitely handled
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4061) // enum 'x' in switch of enum 'y' is not explicitly handled
     #define DOCTEST_GENERATE_ASSERT_TYPE_CASE(assert_type) case assertType::DT_ ## assert_type: return #assert_type
     #define DOCTEST_GENERATE_ASSERT_TYPE_CASES(assert_type) \
         DOCTEST_GENERATE_ASSERT_TYPE_CASE(WARN_ ## assert_type); \
@@ -4105,11 +4157,13 @@ namespace {
         return false;
     }
 
+    DOCTEST_NO_SANITIZE_INTEGER
     unsigned long long hash(unsigned long long a, unsigned long long b) {
         return (a << 5) + b;
     }
 
     // C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
+    DOCTEST_NO_SANITIZE_INTEGER
     unsigned long long hash(const char* str) {
         unsigned long long hash = 5381;
         char c;
@@ -4949,7 +5003,7 @@ namespace detail {
             m_string = tlssPop();
             logged = true;
         }
-        
+
         DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);
 
         const bool isWarn = m_severity & assertType::is_warn;
@@ -5018,7 +5072,11 @@ namespace {
             mutable XmlWriter* m_writer = nullptr;
         };
 
+#ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
         XmlWriter( std::ostream& os = std::cout );
+#else // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+        XmlWriter( std::ostream& os );
+#endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
         ~XmlWriter();
 
         XmlWriter( XmlWriter const& ) = delete;
@@ -5500,7 +5558,7 @@ namespace {
             test_case_start_impl(in);
             xml.ensureTagClosed();
         }
-        
+
         void test_case_reenter(const TestCaseData&) override {}
 
         void test_case_end(const CurrentTestCaseStats& st) override {
@@ -5848,7 +5906,22 @@ namespace {
             testCaseData.addFailure(rb.m_decomp.c_str(), assertString(rb.m_at), os.str());
         }
 
-        void log_message(const MessageData&) override {}
+        void log_message(const MessageData& mb) override {
+            if(mb.m_severity & assertType::is_warn) // report only failures
+                return;
+
+            DOCTEST_LOCK_MUTEX(mutex)
+
+            std::ostringstream os;
+            os << skipPathFromFilename(mb.m_file) << (opt.gnu_file_line ? ":" : "(")
+              << line(mb.m_line) << (opt.gnu_file_line ? ":" : "):") << std::endl;
+
+            os << mb.m_string.c_str() << "\n";
+            log_contexts(os);
+
+            testCaseData.addFailure(mb.m_string.c_str(),
+                mb.m_severity & assertType::is_check ? "FAIL_CHECK" : "FAIL", os.str());
+        }
 
         void test_case_skipped(const TestCaseData&) override {}
 
@@ -6188,9 +6261,9 @@ namespace {
             separator_to_stream();
             s << std::dec;
 
-            auto totwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
-            auto passwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
-            auto failwidth = int(std::ceil(log10((std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
+            auto totwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
+            auto passwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
+            auto failwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
             const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
             s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
               << p.numTestCasesPassingFilters << " | "
@@ -6222,7 +6295,7 @@ namespace {
             subcasesStack.clear();
             currentSubcaseLevel = 0;
         }
-        
+
         void test_case_reenter(const TestCaseData&) override {
             subcasesStack.clear();
         }
@@ -6739,8 +6812,12 @@ int Context::run() {
             fstr.open(p->out.c_str(), std::fstream::out);
             p->cout = &fstr;
         } else {
+#ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
             // stdout by default
             p->cout = &std::cout;
+#else // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+            return EXIT_FAILURE;
+#endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
         }
     }
 
@@ -6905,7 +6982,7 @@ int Context::run() {
             DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
 
             p->timer.start();
-            
+
             bool run_test = true;
 
             do {
@@ -6946,7 +7023,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
                     run_test = false;
                     p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
                 }
-                
+
                 if(!p->nextSubcaseStack.empty() && run_test)
                     DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
                 if(p->nextSubcaseStack.empty())
@@ -7017,3 +7094,13 @@ DOCTEST_SUPPRESS_COMMON_WARNINGS_POP
 
 #endif // DOCTEST_LIBRARY_IMPLEMENTATION
 #endif // DOCTEST_CONFIG_IMPLEMENT
+
+#ifdef DOCTEST_UNDEF_WIN32_LEAN_AND_MEAN
+#undef WIN32_LEAN_AND_MEAN
+#undef DOCTEST_UNDEF_WIN32_LEAN_AND_MEAN
+#endif // DOCTEST_UNDEF_WIN32_LEAN_AND_MEAN
+
+#ifdef DOCTEST_UNDEF_NOMINMAX
+#undef NOMINMAX
+#undef DOCTEST_UNDEF_NOMINMAX
+#endif // DOCTEST_UNDEF_NOMINMAX

--- a/tests/test_cobs_decode.cc
+++ b/tests/test_cobs_decode.cc
@@ -4,23 +4,17 @@
 
 TEST_CASE("Decoding validation") {
   unsigned char dec[32];
-  unsigned dec_len;
+  size_t dec_len;
 
   SUBCASE("Invalid payload: jump past end") {
-    byte_vec_t enc{3, 0};
-    REQUIRE(cobs_decode(enc.data(),
-                        unsigned(enc.size()),
-                        dec,
-                        sizeof(dec),
-                        &dec_len) == COBS_RET_ERR_BAD_PAYLOAD);
+    byte_vec_t enc{ 3, 0 };
+    REQUIRE(cobs_decode(enc.data(), enc.size(), dec, sizeof(dec), &dec_len) ==
+            COBS_RET_ERR_BAD_PAYLOAD);
   }
 
   SUBCASE("Invalid payload: jump over internal zeroes") {
-    byte_vec_t enc{5, 1, 0, 0, 1, 0};
-    REQUIRE(cobs_decode(enc.data(),
-                        unsigned(enc.size()),
-                        dec,
-                        sizeof(dec),
-                        &dec_len) == COBS_RET_ERR_BAD_PAYLOAD);
+    byte_vec_t enc{ 5, 1, 0, 0, 1, 0 };
+    REQUIRE(cobs_decode(enc.data(), enc.size(), dec, sizeof(dec), &dec_len) ==
+            COBS_RET_ERR_BAD_PAYLOAD);
   }
 }

--- a/tests/test_cobs_encode.cc
+++ b/tests/test_cobs_encode.cc
@@ -5,10 +5,10 @@
 #include <cstring>
 
 TEST_CASE("Encoding validation") {
-  unsigned char enc[32], dec[32];
-  unsigned const enc_n = sizeof(enc);
-  unsigned const dec_n = sizeof(dec);
-  unsigned enc_len;
+  byte_t enc[32], dec[32];
+  size_t constexpr enc_n{ sizeof(enc) };
+  size_t constexpr dec_n{ sizeof(dec) };
+  size_t enc_len;
 
   SUBCASE("Null buffer pointer") {
     REQUIRE(cobs_encode(nullptr, dec_n, enc, enc_n, &enc_len) == COBS_RET_ERR_BAD_ARG);
@@ -25,27 +25,25 @@ TEST_CASE("Encoding validation") {
 }
 
 TEST_CASE("Simple encodings") {
-  unsigned char dec[16];
-  unsigned char enc[16];
-  unsigned enc_len;
+  byte_t dec[16], enc[16];
+  size_t enc_len;
 
   SUBCASE("Empty") {
     REQUIRE(cobs_encode(&dec, 0, enc, sizeof(enc), &enc_len) == COBS_RET_SUCCESS);
-    REQUIRE(byte_vec_t(enc, enc + enc_len) == byte_vec_t{0x01, 0x00});
+    REQUIRE(byte_vec_t(enc, enc + enc_len) == byte_vec_t{ 0x01, 0x00 });
   }
 
   SUBCASE("1 nonzero byte") {
     dec[0] = 0x34;
     REQUIRE(cobs_encode(&dec, 1, enc, sizeof(enc), &enc_len) == COBS_RET_SUCCESS);
-    REQUIRE(byte_vec_t(enc, enc + enc_len) == byte_vec_t{0x02, 0x34, 0x00});
+    REQUIRE(byte_vec_t(enc, enc + enc_len) == byte_vec_t{ 0x02, 0x34, 0x00 });
   }
 
   SUBCASE("2 nonzero bytes") {
     dec[0] = 0x34;
     dec[1] = 0x56;
     REQUIRE(cobs_encode(&dec, 2, enc, sizeof(enc), &enc_len) == COBS_RET_SUCCESS);
-    REQUIRE(byte_vec_t(enc, enc + enc_len) ==
-            byte_vec_t{0x03, 0x34, 0x56, 0x00});
+    REQUIRE(byte_vec_t(enc, enc + enc_len) == byte_vec_t{ 0x03, 0x34, 0x56, 0x00 });
   }
 
   SUBCASE("8 nonzero bytes") {
@@ -59,28 +57,27 @@ TEST_CASE("Simple encodings") {
     dec[7] = 0xFF;
     REQUIRE(cobs_encode(&dec, 8, enc, sizeof(enc), &enc_len) == COBS_RET_SUCCESS);
     REQUIRE(byte_vec_t(enc, enc + enc_len) ==
-            byte_vec_t{0x09,0x12,0x34,0x56,0x78,0x9A,0xBC,0xDE,0xFF,0x00});
+            byte_vec_t{ 0x09, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xFF, 0x00 });
   }
 
   SUBCASE("1 zero byte") {
     dec[0] = 0x00;
     REQUIRE(cobs_encode(&dec, 1, enc, sizeof(enc), &enc_len) == COBS_RET_SUCCESS);
-    REQUIRE(byte_vec_t(enc, enc + enc_len) == byte_vec_t{0x01, 0x01, 0x00});
+    REQUIRE(byte_vec_t(enc, enc + enc_len) == byte_vec_t{ 0x01, 0x01, 0x00 });
   }
 
   SUBCASE("2 zero bytes") {
     dec[0] = 0x00;
     dec[1] = 0x00;
     REQUIRE(cobs_encode(&dec, 2, enc, sizeof(enc), &enc_len) == COBS_RET_SUCCESS);
-    REQUIRE(byte_vec_t(enc, enc + enc_len) ==
-            byte_vec_t{0x01, 0x01, 0x01, 0x00});
+    REQUIRE(byte_vec_t(enc, enc + enc_len) == byte_vec_t{ 0x01, 0x01, 0x01, 0x00 });
   }
 
   SUBCASE("8 nonzero bytes") {
     memset(dec, 0, 8);
     REQUIRE(cobs_encode(&dec, 8, enc, sizeof(enc), &enc_len) == COBS_RET_SUCCESS);
     REQUIRE(byte_vec_t(enc, enc + enc_len) ==
-             byte_vec_t{0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x00});
+            byte_vec_t{ 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00 });
   }
 
   SUBCASE("4 alternating zero/nonzero bytes") {
@@ -90,22 +87,19 @@ TEST_CASE("Simple encodings") {
     dec[3] = 0x22;
     REQUIRE(cobs_encode(&dec, 4, enc, sizeof(enc), &enc_len) == COBS_RET_SUCCESS);
     REQUIRE(byte_vec_t(enc, enc + enc_len) ==
-            byte_vec_t{0x01, 0x02, 0x11, 0x02, 0x22, 0x00});
+            byte_vec_t{ 0x01, 0x02, 0x11, 0x02, 0x22, 0x00 });
   }
 }
 
 namespace {
 byte_vec_t encode(byte_vec_t const &decoded) {
-  byte_vec_t enc(COBS_ENCODE_MAX(static_cast< unsigned >(decoded.size())));
-  unsigned enc_len;
-  REQUIRE(cobs_encode(decoded.data(),
-                      static_cast< unsigned >(decoded.size()),
-                      enc.data(),
-                      static_cast< unsigned >(enc.size()),
-                      &enc_len) == COBS_RET_SUCCESS);
-  return byte_vec_t(enc.begin(), enc.begin() + enc_len);
+  byte_vec_t enc(COBS_ENCODE_MAX(static_cast<unsigned>(decoded.size())));
+  size_t enc_len;
+  REQUIRE(cobs_encode(decoded.data(), decoded.size(), enc.data(), enc.size(), &enc_len) ==
+          COBS_RET_SUCCESS);
+  return byte_vec_t(enc.data(), enc.data() + enc_len);
 }
-}
+}  // namespace
 
 TEST_CASE("0xFF single code-block case") {
   byte_vec_t expected(255, 0x01);
@@ -116,9 +110,9 @@ TEST_CASE("0xFF single code-block case") {
 
 TEST_CASE("Longer payloads") {
   SUBCASE("255 non-zero bytes") {
-    byte_vec_t expected{0xFF};
+    byte_vec_t expected{ 0xFF };
     expected.insert(std::end(expected), 254, 0x01);
-    expected.push_back(0x02); // code: distance to next block
+    expected.push_back(0x02);  // code: distance to next block
     expected.push_back(0x01);
     expected.push_back(0x00);
     REQUIRE(encode(byte_vec_t(255, 0x01)) == expected);
@@ -132,7 +126,7 @@ TEST_CASE("Longer payloads") {
 
   SUBCASE("1024 non-zero bytes") {
     byte_vec_t expected;
-    for (auto i = 0u; i < 1024 / 254; ++i) {
+    for (auto i{ 0u }; i < 1024 / 254; ++i) {
       expected.push_back(0xFF);
       expected.insert(std::end(expected), 254, '!');
     }
@@ -150,12 +144,12 @@ TEST_CASE("Longer payloads") {
 
   SUBCASE("1024 every other byte is zero") {
     byte_vec_t dec;
-    for (auto i = 0u; i < 1024; ++i) {
+    for (auto i{ 0u }; i < 1024; ++i) {
       dec.push_back(i & 1);
     }
 
     byte_vec_t expected;
-    for (auto i = 0u; i <= 1024; ++i) {
+    for (auto i{ 0u }; i <= 1024; ++i) {
       expected.push_back((i & 1) ? 2 : 1);
     }
     expected.push_back(0x00);

--- a/tests/test_cobs_encode_inc.cc
+++ b/tests/test_cobs_encode_inc.cc
@@ -164,16 +164,13 @@ TEST_CASE("cobs_encode_inc_end") {
 }
 
 namespace {
-byte_vec_t encode_single(byte_vec_t const &decoded) {
-  byte_vec_t encoded(COBS_ENCODE_MAX(decoded.size()));
+byte_vec_t encode_single(byte_vec_t const &dec) {
+  byte_vec_t enc(COBS_ENCODE_MAX(dec.size()));
   size_t enc_len;
-  REQUIRE(cobs_encode(decoded.data(),
-                      decoded.size(),
-                      encoded.data(),
-                      encoded.size(),
-                      &enc_len) == COBS_RET_SUCCESS);
-  encoded.resize(enc_len);
-  return encoded;
+  REQUIRE(cobs_encode(dec.data(), dec.size(), enc.data(), enc.size(), &enc_len) ==
+          COBS_RET_SUCCESS);
+  enc.resize(enc_len);
+  return enc;
 }
 
 byte_vec_t encode_incremental(byte_vec_t const &decoded, size_t chunk_size) {
@@ -183,9 +180,8 @@ byte_vec_t encode_incremental(byte_vec_t const &decoded, size_t chunk_size) {
   REQUIRE(cobs_encode_inc_begin(encoded.data(), encoded.size(), &ctx) == COBS_RET_SUCCESS);
 
   size_t cur = 0;
-  size_t const n{ decoded.size() };
-  while (cur < n) {
-    size_t const encode_size{ std::min(chunk_size, n - cur) };
+  while (cur < decoded.size()) {
+    size_t const encode_size{ std::min(chunk_size, decoded.size() - cur) };
     REQUIRE(cobs_encode_inc(&ctx, &decoded[cur], encode_size) == COBS_RET_SUCCESS);
     cur += encode_size;
   }

--- a/tests/test_cobs_encode_inplace.cc
+++ b/tests/test_cobs_encode_inplace.cc
@@ -8,10 +8,10 @@
 static constexpr byte_t CSV = COBS_INPLACE_SENTINEL_VALUE;
 
 namespace {
-  cobs_ret_t cobs_encode_vec(byte_vec_t &v) {
-    return cobs_encode_inplace(v.data(), static_cast< unsigned >(v.size()));
-  }
+cobs_ret_t cobs_encode_vec(byte_vec_t &v) {
+  return cobs_encode_inplace(v.data(), v.size());
 }
+}  // namespace
 
 TEST_CASE("Inplace encoding validation") {
   SUBCASE("Null buffer pointer") {
@@ -25,23 +25,23 @@ TEST_CASE("Inplace encoding validation") {
   }
 
   SUBCASE("Invalid sentinel values") {
-    byte_vec_t buf{CSV - 1, CSV - 1};
+    byte_vec_t buf{ CSV - 1, CSV - 1 };
     REQUIRE(cobs_encode_vec(buf) == COBS_RET_ERR_BAD_PAYLOAD);
-    buf = byte_vec_t{CSV, CSV - 1};
+    buf = byte_vec_t{ CSV, CSV - 1 };
     REQUIRE(cobs_encode_vec(buf) == COBS_RET_ERR_BAD_PAYLOAD);
-    buf = byte_vec_t{CSV - 1, CSV};
+    buf = byte_vec_t{ CSV - 1, CSV };
     REQUIRE(cobs_encode_vec(buf) == COBS_RET_ERR_BAD_PAYLOAD);
   }
 
   SUBCASE("Nonzero run longer than 255") {
-    byte_vec_t buf{CSV};
+    byte_vec_t buf{ CSV };
     buf.insert(std::end(buf), 256, 0x01);
     buf.push_back(CSV);
     REQUIRE(cobs_encode_vec(buf) == COBS_RET_ERR_BAD_PAYLOAD);
   }
 
   SUBCASE("Non-final run of 255 bytes") {
-    byte_vec_t buf{CSV, 0x00};
+    byte_vec_t buf{ CSV, 0x00 };
     buf.insert(std::end(buf), 255, 1);
     buf.push_back(0x00);
     buf.push_back(CSV);
@@ -51,25 +51,25 @@ TEST_CASE("Inplace encoding validation") {
 
 TEST_CASE("Inplace encoding") {
   SUBCASE("Empty") {
-    byte_vec_t buf{CSV, CSV};
+    byte_vec_t buf{ CSV, CSV };
     REQUIRE(cobs_encode_vec(buf) == COBS_RET_SUCCESS);
-    REQUIRE(buf == byte_vec_t{0x01, 0x00});
+    REQUIRE(buf == byte_vec_t{ 0x01, 0x00 });
   }
 
   SUBCASE("One nonzero byte") {
-    byte_vec_t buf{CSV, 0x01, CSV};
+    byte_vec_t buf{ CSV, 0x01, CSV };
     REQUIRE(cobs_encode_vec(buf) == COBS_RET_SUCCESS);
-    REQUIRE(buf == byte_vec_t{0x02, 0x01, 0x00});
+    REQUIRE(buf == byte_vec_t{ 0x02, 0x01, 0x00 });
   }
 
   SUBCASE("One zero byte") {
-    byte_vec_t buf{CSV, 0x00, CSV};
+    byte_vec_t buf{ CSV, 0x00, CSV };
     REQUIRE(cobs_encode_vec(buf) == COBS_RET_SUCCESS);
-    REQUIRE(buf == byte_vec_t{0x01, 0x01, 0x00});
+    REQUIRE(buf == byte_vec_t{ 0x01, 0x01, 0x00 });
   }
 
   SUBCASE("Longest possible run of 254 bytes") {
-    byte_vec_t buf{CSV, 0x00};
+    byte_vec_t buf{ CSV, 0x00 };
     buf.insert(std::end(buf), 254, 1);
     buf.push_back(CSV);
     REQUIRE(cobs_encode_vec(buf) == COBS_RET_SUCCESS);
@@ -77,33 +77,33 @@ TEST_CASE("Inplace encoding") {
 
   SUBCASE("Safe payload, all zero bytes") {
     byte_vec_t buf(COBS_INPLACE_SAFE_BUFFER_SIZE);
-    std::fill(std::begin(buf), std::end(buf), byte_t{0x00});
+    std::fill(std::begin(buf), std::end(buf), byte_t{ 0x00 });
     buf[0] = CSV;
     buf[buf.size() - 1] = CSV;
     REQUIRE(cobs_encode_vec(buf) == COBS_RET_SUCCESS);
 
     byte_vec_t expected(buf.size());
-    std::fill(std::begin(expected), std::end(expected), byte_t{0x01});
+    std::fill(std::begin(expected), std::end(expected), byte_t{ 0x01 });
     expected[expected.size() - 1] = 0x00;
     REQUIRE(buf == expected);
   }
 
   SUBCASE("Safe payload, no zero bytes") {
     byte_vec_t buf(COBS_INPLACE_SAFE_BUFFER_SIZE);
-    std::iota(std::begin(buf), std::end(buf), byte_t{0x00});
+    std::iota(std::begin(buf), std::end(buf), byte_t{ 0x00 });
     buf[0] = CSV;
     buf[buf.size() - 1] = CSV;
     REQUIRE(cobs_encode_vec(buf) == COBS_RET_SUCCESS);
 
     byte_vec_t expected(buf.size());
-    std::iota(std::begin(expected), std::end(expected), byte_t{0x00});
+    std::iota(std::begin(expected), std::end(expected), byte_t{ 0x00 });
     expected[0] = 0xFF;
     expected[expected.size() - 1] = 0x00;
     REQUIRE(buf == expected);
   }
 
   SUBCASE("Unsafe payload with 254B jumps") {
-    byte_vec_t buf{CSV};
+    byte_vec_t buf{ CSV };
     buf.insert(std::end(buf), 254, 0x01);
     buf.push_back(0x00);
     buf.insert(std::end(buf), 254, 0x01);
@@ -112,7 +112,7 @@ TEST_CASE("Inplace encoding") {
     buf.push_back(CSV);
     REQUIRE(cobs_encode_vec(buf) == COBS_RET_SUCCESS);
 
-    byte_vec_t expected{0xFF};
+    byte_vec_t expected{ 0xFF };
     expected.insert(std::end(expected), 254, 0x01);
     expected.push_back(0xFF);
     expected.insert(std::end(expected), 254, 0x01);
@@ -124,28 +124,28 @@ TEST_CASE("Inplace encoding") {
 }
 
 namespace {
-void verify_encode_inplace(unsigned char *inplace, unsigned payload_len) {
+void verify_encode_inplace(byte_t *inplace, size_t payload_len) {
   byte_vec_t external(COBS_ENCODE_MAX(payload_len));
-  unsigned external_len;
+  size_t external_len;
   REQUIRE(cobs_encode(inplace + 1,
                       payload_len,
                       external.data(),
-                      static_cast< unsigned >(external.size()),
+                      external.size(),
                       &external_len) == COBS_RET_SUCCESS);
 
   REQUIRE(cobs_encode_inplace(inplace, payload_len + 2) == COBS_RET_SUCCESS);
   REQUIRE(byte_vec_t(inplace, inplace + payload_len + 2) == external);
 }
 
-void fill_inplace(unsigned char *inplace, unsigned payload_len, unsigned char f) {
+void fill_inplace(byte_t *inplace, size_t payload_len, byte_t f) {
   memset(inplace + 1, f, payload_len);
   inplace[0] = COBS_INPLACE_SENTINEL_VALUE;
-  inplace[payload_len+1] = COBS_INPLACE_SENTINEL_VALUE;
+  inplace[payload_len + 1] = COBS_INPLACE_SENTINEL_VALUE;
 }
-}
+}  // namespace
 
 TEST_CASE("Encode: Inplace == External") {
-  unsigned char inplace[COBS_INPLACE_SAFE_BUFFER_SIZE];
+  byte_t inplace[COBS_INPLACE_SAFE_BUFFER_SIZE];
 
   SUBCASE("Fill with zeros") {
     for (auto i = 0u; i < sizeof(inplace) - 2; ++i) {

--- a/tests/test_cobs_encode_max.cc
+++ b/tests/test_cobs_encode_max.cc
@@ -1,3 +1,4 @@
+#include "cobs_encode_max_c.h"
 #include "../cobs.h"
 #include "doctest.h"
 
@@ -6,27 +7,33 @@ enum { WORKS_AT_COMPILE_TIME = COBS_ENCODE_MAX(123) };
 TEST_CASE("COBS_ENCODE_MAX") {
   SUBCASE("0 bytes") {
     REQUIRE(COBS_ENCODE_MAX(0) == 2);
+    REQUIRE(cobs_encode_max_c(0) == 2);
   }
   SUBCASE("1 byte") {
     REQUIRE(COBS_ENCODE_MAX(1) == 3);
+    REQUIRE(cobs_encode_max_c(1) == 3);
   }
   SUBCASE("2 bytes") {
     REQUIRE(COBS_ENCODE_MAX(2) == 4);
+    REQUIRE(cobs_encode_max_c(2) == 4);
   }
 
   SUBCASE("3 - 254 bytes") {
     for (auto i{ 3u }; i <= 254u; ++i) {
       REQUIRE(COBS_ENCODE_MAX(i) == i + 2);
+      REQUIRE(cobs_encode_max_c(i) == i + 2);
     }
   }
 
   SUBCASE("255-508 bytes") {
     for (auto i{ 255u }; i <= 508u; ++i) {
       REQUIRE(COBS_ENCODE_MAX(i) == i + 3);
+      REQUIRE(cobs_encode_max_c(i) == i + 3);
     }
   }
 
   SUBCASE("Input size plus boilerplate plus ceil(x/254)") {
     REQUIRE(COBS_ENCODE_MAX(12345) == 1 + 12345 + ((12345 + 253) / 254));
+    REQUIRE(cobs_encode_max_c(12345) == 1 + 12345 + ((12345 + 253) / 254));
   }
 }

--- a/tests/test_cobs_encode_max.cc
+++ b/tests/test_cobs_encode_max.cc
@@ -1,23 +1,29 @@
 #include "../cobs.h"
 #include "doctest.h"
 
-enum {
-  WORKS_AT_COMPILE_TIME = COBS_ENCODE_MAX(123)
-};
+enum { WORKS_AT_COMPILE_TIME = COBS_ENCODE_MAX(123) };
 
 TEST_CASE("COBS_ENCODE_MAX") {
-  SUBCASE("0 bytes") { REQUIRE(COBS_ENCODE_MAX(0) == 2); }
-  SUBCASE("1 byte")  { REQUIRE(COBS_ENCODE_MAX(1) == 3); }
-  SUBCASE("2 bytes") { REQUIRE(COBS_ENCODE_MAX(2) == 4); }
+  SUBCASE("0 bytes") {
+    REQUIRE(COBS_ENCODE_MAX(0) == 2);
+  }
+  SUBCASE("1 byte") {
+    REQUIRE(COBS_ENCODE_MAX(1) == 3);
+  }
+  SUBCASE("2 bytes") {
+    REQUIRE(COBS_ENCODE_MAX(2) == 4);
+  }
 
   SUBCASE("3 - 254 bytes") {
-    for (auto i = 3u; i <= 254u; ++i) {
+    for (auto i{ 3u }; i <= 254u; ++i) {
       REQUIRE(COBS_ENCODE_MAX(i) == i + 2);
     }
   }
 
   SUBCASE("255-508 bytes") {
-    for (auto i = 255u; i <= 508u; ++i) { REQUIRE(COBS_ENCODE_MAX(i) == i + 3); }
+    for (auto i{ 255u }; i <= 508u; ++i) {
+      REQUIRE(COBS_ENCODE_MAX(i) == i + 3);
+    }
   }
 
   SUBCASE("Input size plus boilerplate plus ceil(x/254)") {

--- a/tests/test_paper_figures.cc
+++ b/tests/test_paper_figures.cc
@@ -2,7 +2,6 @@
 #include "byte_vec.h"
 #include "doctest.h"
 
-
 // http://www.stuartcheshire.org/papers/COBSforToN.pdf
 TEST_CASE("COBS paper examples") {
   SUBCASE("Figure 2") {
@@ -10,16 +9,15 @@ TEST_CASE("COBS paper examples") {
     input[input.size() - 1] = 0x00;
 
     byte_vec_t output(684);
-    unsigned output_len;
+    size_t output_len;
 
     REQUIRE(cobs_encode(input.data(),
-                         static_cast< unsigned >(input.size()),
-                         output.data(),
-                         static_cast< unsigned >(output.size()),
-                         &output_len) == COBS_RET_SUCCESS);
+                        input.size(),
+                        output.data(),
+                        output.size(),
+                        &output_len) == COBS_RET_SUCCESS);
 
-
-    byte_vec_t expected{0xFF};
+    byte_vec_t expected{ 0xFF };
     expected.insert(std::end(expected), 254, 0x01);
     expected.push_back(0xFF);
     expected.insert(std::end(expected), 254, 0x01);
@@ -30,18 +28,19 @@ TEST_CASE("COBS paper examples") {
   }
 
   SUBCASE("Figure 3") {
-    byte_vec_t input {0x45,0x00,0x00,0x2C,0x4C,0x79,0x00,0x00,0x40,0x06,0x4F,0x37};
-    byte_vec_t output
-        {0x02,0x45,0x01,0x04,0x2C,0x4C,0x79,0x01,0x05,0x40,0x06,0x4F,0x37,0x00};
+    byte_vec_t input{ 0x45, 0x00, 0x00, 0x2C, 0x4C, 0x79,
+                      0x00, 0x00, 0x40, 0x06, 0x4F, 0x37 };
+    byte_vec_t output{ 0x02, 0x45, 0x01, 0x04, 0x2C, 0x4C, 0x79,
+                       0x01, 0x05, 0x40, 0x06, 0x4F, 0x37, 0x00 };
 
-    char encoded[256];
-    unsigned encoded_len;
+    std::array<byte_t, 256> encoded;
+    size_t encoded_len;
 
     REQUIRE(cobs_encode(input.data(),
-                        static_cast< unsigned >(input.size()),
-                        encoded,
-                        sizeof(encoded),
+                        input.size(),
+                        encoded.data(),
+                        encoded.size(),
                         &encoded_len) == COBS_RET_SUCCESS);
-    REQUIRE(output == byte_vec_t(encoded, encoded + encoded_len));
+    REQUIRE(output == byte_vec_t(encoded.data(), encoded.data() + encoded_len));
   }
 }

--- a/tests/test_wikipedia.cc
+++ b/tests/test_wikipedia.cc
@@ -4,91 +4,90 @@
 
 #include <numeric>
 
-static constexpr byte_t CSV = COBS_INPLACE_SENTINEL_VALUE;
+static constexpr byte_t CSV{ COBS_INPLACE_SENTINEL_VALUE };
 
 namespace {
-void round_trip_inplace(byte_vec_t const &decoded,
-                        byte_vec_t const &encoded) {
-  byte_vec_t decoded_inplace{CSV};
-  decoded_inplace.insert(
-    std::end(decoded_inplace), std::begin(decoded), std::end(decoded));
+void round_trip_inplace(byte_vec_t const &decoded, byte_vec_t const &encoded) {
+  byte_vec_t decoded_inplace{ CSV };
+  decoded_inplace.insert(std::end(decoded_inplace),
+                         std::begin(decoded),
+                         std::end(decoded));
   decoded_inplace.push_back(CSV);
 
   byte_vec_t x(decoded_inplace);
-  unsigned const n = static_cast< unsigned >(x.size());
 
-  REQUIRE(cobs_encode_inplace(x.data(), n) == COBS_RET_SUCCESS);
+  REQUIRE(cobs_encode_inplace(x.data(), x.size()) == COBS_RET_SUCCESS);
   REQUIRE(x == encoded);
-  REQUIRE(cobs_decode_inplace(x.data(), n) == COBS_RET_SUCCESS);
+  REQUIRE(cobs_decode_inplace(x.data(), x.size()) == COBS_RET_SUCCESS);
   REQUIRE(x == decoded_inplace);
 }
 
 void round_trip(byte_vec_t const &decoded, byte_vec_t const &encoded) {
-  unsigned char enc_actual[512], dec_actual[512];
-  unsigned enc_actual_len, dec_actual_len;
+  std::array<byte_t, 512> enc_actual, dec_actual;
+  size_t enc_actual_len, dec_actual_len;
 
   REQUIRE(cobs_encode(decoded.data(),
-                      static_cast< unsigned >(decoded.size()),
-                      enc_actual,
-                      sizeof(enc_actual),
+                      decoded.size(),
+                      enc_actual.data(),
+                      enc_actual.size(),
                       &enc_actual_len) == COBS_RET_SUCCESS);
 
-  REQUIRE(encoded == byte_vec_t(enc_actual, enc_actual + enc_actual_len));
+  REQUIRE(encoded == byte_vec_t(enc_actual.data(), enc_actual.data() + enc_actual_len));
 
-  REQUIRE(cobs_decode(enc_actual,
+  REQUIRE(cobs_decode(enc_actual.data(),
                       enc_actual_len,
-                      dec_actual,
-                      sizeof(dec_actual),
+                      dec_actual.data(),
+                      dec_actual.size(),
                       &dec_actual_len) == COBS_RET_SUCCESS);
 
-  REQUIRE(decoded == byte_vec_t(dec_actual, dec_actual + dec_actual_len));
+  REQUIRE(decoded == byte_vec_t(dec_actual.data(), dec_actual.data() + dec_actual_len));
 
   // Additionaly, in-place decode atop enc_actual using cobs_decode.
 
-  REQUIRE(cobs_decode(enc_actual,
+  REQUIRE(cobs_decode(enc_actual.data(),
                       enc_actual_len,
-                      enc_actual,
-                      sizeof(enc_actual),
+                      enc_actual.data(),
+                      enc_actual.size(),
                       &dec_actual_len) == COBS_RET_SUCCESS);
 
-  REQUIRE(decoded == byte_vec_t(enc_actual, enc_actual + dec_actual_len));
+  REQUIRE(decoded == byte_vec_t(enc_actual.data(), enc_actual.data() + dec_actual_len));
 }
-}
+}  // namespace
 
 // https://wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing#Encoding_examples
 
 TEST_CASE("Wikipedia round-trip examples") {
   SUBCASE("Example 1") {
-    const byte_vec_t decoded{0x00};
-    const byte_vec_t encoded{0x01, 0x01, 0x00};
+    const byte_vec_t decoded{ 0x00 };
+    const byte_vec_t encoded{ 0x01, 0x01, 0x00 };
     round_trip_inplace(decoded, encoded);
     round_trip(decoded, encoded);
   }
 
   SUBCASE("Example 2") {
-    const byte_vec_t decoded{0x00, 0x00};
-    const byte_vec_t encoded{0x01, 0x01, 0x01, 0x00};
+    const byte_vec_t decoded{ 0x00, 0x00 };
+    const byte_vec_t encoded{ 0x01, 0x01, 0x01, 0x00 };
     round_trip_inplace(decoded, encoded);
     round_trip(decoded, encoded);
   }
 
   SUBCASE("Example 3") {
-    const byte_vec_t decoded{0x11, 0x22, 0x00, 0x33};
-    const byte_vec_t encoded{0x03, 0x11, 0x22, 0x02, 0x33, 0x00};
+    const byte_vec_t decoded{ 0x11, 0x22, 0x00, 0x33 };
+    const byte_vec_t encoded{ 0x03, 0x11, 0x22, 0x02, 0x33, 0x00 };
     round_trip_inplace(decoded, encoded);
     round_trip(decoded, encoded);
   }
 
   SUBCASE("Example 4") {
-    const byte_vec_t decoded{0x11, 0x22, 0x33, 0x44};
-    const byte_vec_t encoded{0x05, 0x11, 0x22, 0x33, 0x44, 0x00};
+    const byte_vec_t decoded{ 0x11, 0x22, 0x33, 0x44 };
+    const byte_vec_t encoded{ 0x05, 0x11, 0x22, 0x33, 0x44, 0x00 };
     round_trip_inplace(decoded, encoded);
     round_trip(decoded, encoded);
   }
 
   SUBCASE("Example 5") {
-    const byte_vec_t decoded{0x11, 0x00, 0x00, 0x00};
-    const byte_vec_t encoded{0x02, 0x11, 0x01, 0x01, 0x01, 0x00};
+    const byte_vec_t decoded{ 0x11, 0x00, 0x00, 0x00 };
+    const byte_vec_t encoded{ 0x02, 0x11, 0x01, 0x01, 0x01, 0x00 };
     round_trip_inplace(decoded, encoded);
     round_trip(decoded, encoded);
   }
@@ -96,11 +95,11 @@ TEST_CASE("Wikipedia round-trip examples") {
   SUBCASE("Example 6") {
     // 01 02 03 ... FD FE
     byte_vec_t decoded(254);
-    std::iota(std::begin(decoded), std::end(decoded), byte_t{0x01});
+    std::iota(std::begin(decoded), std::end(decoded), byte_t{ 0x01 });
 
     // FF 01 02 03 ... FD FE 00
     byte_vec_t encoded(255);
-    std::iota(std::begin(encoded), std::end(encoded), byte_t{0x00});
+    std::iota(std::begin(encoded), std::end(encoded), byte_t{ 0x00 });
     encoded[0] = 0xFF;
     encoded.push_back(0x00);
 
@@ -111,11 +110,11 @@ TEST_CASE("Wikipedia round-trip examples") {
   SUBCASE("Example 7") {
     // 00 01 02 ... FC FD FE
     byte_vec_t decoded(255);
-    std::iota(std::begin(decoded), std::end(decoded), byte_t{0x00});
+    std::iota(std::begin(decoded), std::end(decoded), byte_t{ 0x00 });
 
     // 01 FF 01 02 ... FC FD FE 00
-    byte_vec_t encoded{0x01, 0xFF};
-    for (unsigned char i = 0x01u; i <= 0xFE; ++i) {
+    byte_vec_t encoded{ 0x01, 0xFF };
+    for (byte_t i{ 0x01u }; i <= 0xFE; ++i) {
       encoded.push_back(i);
     }
     encoded.push_back(0x00);
@@ -127,13 +126,13 @@ TEST_CASE("Wikipedia round-trip examples") {
   SUBCASE("Example 8") {
     // 01 02 03 ... FD FE FF
     byte_vec_t decoded(255);
-    std::iota(std::begin(decoded), std::end(decoded), byte_t{0x01});
+    std::iota(std::begin(decoded), std::end(decoded), byte_t{ 0x01 });
 
     // FF 01 02 03 ... FD FE 02 FF 00
     byte_vec_t encoded(255);
-    std::iota(std::begin(encoded), std::end(encoded), byte_t{0x00});
+    std::iota(std::begin(encoded), std::end(encoded), byte_t{ 0x00 });
     encoded[0] = 0xFF;
-    encoded.insert(std::end(encoded), {0x02, 0xFF, 0x00});
+    encoded.insert(std::end(encoded), { 0x02, 0xFF, 0x00 });
 
     round_trip(decoded, encoded);
   }
@@ -141,14 +140,14 @@ TEST_CASE("Wikipedia round-trip examples") {
   SUBCASE("Example 9") {
     // 02 03 04 ... FE FF 00
     byte_vec_t decoded(255);
-    std::iota(std::begin(decoded), std::end(decoded), byte_t{0x02});
+    std::iota(std::begin(decoded), std::end(decoded), byte_t{ 0x02 });
     decoded[decoded.size() - 1] = 0x00;
 
     // FF 02 03 04 ... FE FF 01 01 00
     byte_vec_t encoded(255);
-    std::iota(std::begin(encoded), std::end(encoded), byte_t{0x01});
+    std::iota(std::begin(encoded), std::end(encoded), byte_t{ 0x01 });
     encoded[0] = 0xFF;
-    encoded.insert(std::end(encoded), {0x01, 0x01, 0x00});
+    encoded.insert(std::end(encoded), { 0x01, 0x01, 0x00 });
 
     round_trip(decoded, encoded);
   }
@@ -156,15 +155,15 @@ TEST_CASE("Wikipedia round-trip examples") {
   SUBCASE("Example 10") {
     // 03 04 05 ... FF 00 01
     byte_vec_t decoded(253);
-    std::iota(std::begin(decoded), std::end(decoded), byte_t{0x03});
-    decoded.insert(decoded.end(), {0x00, 0x01});
+    std::iota(std::begin(decoded), std::end(decoded), byte_t{ 0x03 });
+    decoded.insert(decoded.end(), { 0x00, 0x01 });
 
     // FE 03 04 05 ... FF 02 01 00
-    byte_vec_t encoded{0xFE};
-    for (auto i = 0x03u; i <= 0xFF; ++i) {
-      encoded.push_back(static_cast< byte_t >(i));
+    byte_vec_t encoded{ 0xFE };
+    for (auto i{ 0x03u }; i <= 0xFF; ++i) {
+      encoded.push_back(static_cast<byte_t>(i));
     }
-    encoded.insert(encoded.end(), {0x02, 0x01, 0x00});
+    encoded.insert(encoded.end(), { 0x02, 0x01, 0x00 });
 
     round_trip_inplace(decoded, encoded);
     round_trip(decoded, encoded);


### PR DESCRIPTION
A large but uninteresting maintenance PR as I'm gearing up to add incremental decoding and overhaul incremental encoding:
* Upgrade doctest
* clang-format the code
* Move the unit tests to use more c++isms