### PR TITLE
incremental encoding to small buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Compile `cobs.c` and link it into your app. `#include "path/to/cobs.h"` in your 
 Fill a buffer with the data you'd like to encode. Prepare a larger buffer to hold the encoded data. Then, call `cobs_encode` to encode the data into the destination buffer.
 
 ```c
-char decoded[64];
+unsigned char decoded[64];
 unsigned const len = fill_with_decoded_data(decoded);
 
-char encoded[128];
+unsigned char encoded[128];
 unsigned encoded_len;
 cobs_ret_t const result = cobs_encode(decoded, len, encoded, sizeof(encoded), &encoded_len);
 
@@ -70,11 +70,11 @@ if (result == COBS_RET_SUCCESS) {
 Decoding works similarly; receive an encoded buffer from somewhere, prepare a buffer to hold the decoded data, and call `cobs_decode`.
 
 ```c
-char encoded[128];
+unsigned char encoded[128];
 unsigned encoded_len;
 get_encoded_data_from_somewhere(encoded, &encoded_len);
 
-char decoded[128];
+unsigned char decoded[128];
 unsigned decoded_len;
 cobs_ret_t const result = cobs_decode(encoded, encoded_len, decoded, sizeof(decoded), &decoded_len);
 
@@ -168,7 +168,7 @@ If you can guarantee that your payloads are shorter than 254 bytes, you can use 
 (Note that `64` is an arbitrary size in this example, you can use any size you want up to `COBS_TINYFRAME_SAFE_BUFFER_SIZE`)
 
 ```c
-char buf[64];
+unsigned char buf[64];
 buf[0] = COBS_TINYFRAME_SENTINEL_VALUE; // You have to do this.
 buf[63] = COBS_TINYFRAME_SENTINEL_VALUE; // You have to do this.
 
@@ -190,7 +190,7 @@ if (result == COBS_RET_SUCCESS) {
 Accumulate data from your source until you encounter a COBS frame delimiter byte of `0x00`. Once you've got that, call `cobs_decode_tinyframe` on that region of a buffer to do an in-place decoding. The zeroth and final bytes of your payload will be replaced with the `COBS_TINYFRAME_SENTINEL_VALUE` bytes that, were you _encoding_ in-place, you would have had to place there anyway.
 
 ```c
-char buf[64];
+unsigned char buf[64];
 
 // You fill 'buf' with an encoded cobs frame (from uart, etc) that ends with 0x00.
 unsigned const length = you_fill_buf_with_data(buf);

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `nanocobs` is a C99 implementation of the [Consistent Overhead Byte Stuffing](https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing) ("COBS") algorithm, defined in the [paper](http://www.stuartcheshire.org/papers/COBSforToN.pdf) by Stuart Cheshire and Mary Baker.
 
-Users can encode and decode data in-place or into separate target buffers. Encoding can be incremental; users can encode multiple small buffers (e.g. header, then payloads) into one target. The `nanocobs` runtime requires no extra memory overhead. No standard library headers are included, and no standard library functions are called.
+Users can encode and decode data in-place or into separate target buffers. Encoding and decoding can both be incremental, streaming data through small caller-provided buffers. The `nanocobs` runtime requires no extra memory overhead. No standard library headers are included, and no standard library functions are called.
 
 ## Rationale
 
@@ -18,36 +18,39 @@ You probably only need `nanocobs` for things like inter-chip communications prot
 
 There are a few out there, but I haven't seen any that optionally encode in-place. This can be handy if you're memory-constrained and would enjoy CPU + RAM optimizations that come from using small frames. Also, the cost of in-place decoding is only as expensive as the number of zeroes in your payload; exploiting that if you're designing your own protocols can make decoding very fast.
 
-None of the other COBS implementations I saw supported incremental encoding. It's often the case in communication stacks that a layer above the link provides a tightly-sized payload buffer, and the link has to encode both a header _and_ this payload into a single frame. That requires an extra buffer for assembling which then immediately gets encoded into yet another buffer. With incremental encoding, a header structure can be created on the stack and encoded into the target, then the payload can follow into the same target.
+None of the other COBS implementations I saw supported incremental encoding and decoding. It's often the case in communication stacks that a layer above the link provides a tightly-sized payload buffer, and the link has to encode both a header _and_ this payload into a single frame. That requires an extra buffer for assembling which then immediately gets encoded into yet another buffer. With incremental encoding, data can be streamed through small buffers without ever needing to allocate the full encoded frame.
 
 Finally, I didn't see as many unit tests as I'd have liked in the other libraries, especially around invalid payload handling. Framing protocols make for lovely attack surfaces, and malicious COBS frames can easily instruct decoders to jump outside of the frame itself.
 
 ## Metrics
 
-It's pretty small, and you probably need either `cobs_[en|de]code_tinyframe` _or_ `cobs_[en|de]code[_inc*]`, but not both.
+It's pretty small, and you probably need either `cobs_[en|de]code_tinyframe` _or_ `cobs_[en|de]code[_inc*]`, but not all of them.
 ```
 ❯ arm-none-eabi-gcc -mthumb -mcpu=cortex-m4 -Os -c cobs.c
 ❯ arm-none-eabi-nm --print-size --size-sort cobs.o
 
-0000011c 0000001e T cobs_encode_inc_end    (30 bytes)
-0000007a 00000022 T cobs_encode_inc_begin  (34 bytes)
-00000048 00000032 T cobs_decode_tinyframe  (50 bytes)
-0000013a 00000034 T cobs_encode            (52 bytes)
-00000000 00000048 T cobs_encode_tinyframe  (72 bytes)
-0000009c 00000080 T cobs_encode_inc        (128 bytes)
-0000016e 00000090 T cobs_decode            (144 bytes)
-Total 1fe (510 bytes)
+000002c4 0000000e T cobs_decode_inc_begin  (14 bytes)
+00000128 0000001c T cobs_encode_inc_begin  (28 bytes)
+00000000 00000022 t flush_block            (34 bytes)
+00000396 00000044 T cobs_decode            (68 bytes)
+0000006a 00000048 T cobs_decode_tinyframe  (72 bytes)
+00000022 00000048 T cobs_encode_tinyframe  (72 bytes)
+000000b2 00000076 T cobs_encode            (118 bytes)
+00000212 000000b2 T cobs_encode_inc_end    (178 bytes)
+000002d2 000000c4 T cobs_decode_inc        (196 bytes)
+00000144 000000ce T cobs_encode_inc        (206 bytes)
+Total 3da (986 bytes)
 ```
 
 ## Usage
 
 Compile `cobs.c` and link it into your app. `#include "path/to/cobs.h"` in your source code. Call functions.
 
-### Encoding With Separate Buffers
+### Encoding
 
 Fill a buffer with the data you'd like to encode. Prepare a larger buffer to hold the encoded data. Then, call `cobs_encode` to encode the data into the destination buffer.
 
-```
+```c
 char decoded[64];
 unsigned const len = fill_with_decoded_data(decoded);
 
@@ -62,11 +65,11 @@ if (result == COBS_RET_SUCCESS) {
 }
 ```
 
-### Decoding 
+### Decoding
 
-Decoding works similarly; receive an encoded buffer from somewhere, prepare a buffer to hold the decoded data, and call `cobs_decode`. Decoding can always be performed in-place, since the encoded frames are always larger than the decoded data. Simply pass the same buffer to the `encoded` and `decoded` parameters and the frame will be decoded in-place.
+Decoding works similarly; receive an encoded buffer from somewhere, prepare a buffer to hold the decoded data, and call `cobs_decode`.
 
-```
+```c
 char encoded[128];
 unsigned encoded_len;
 get_encoded_data_from_somewhere(encoded, &encoded_len);
@@ -84,39 +87,87 @@ if (result == COBS_RET_SUCCESS) {
 
 ### Incremental Encoding
 
-Sometimes it's helpful to be able to encode multiple separate buffers into one target. To do this, use the `cobs_encode_inc` family of functions: initialize a `cobx_enc_ctx_t` in `cobs_encode_inc_begin`, then call `cobs_encode_inc` multiple times, and finish encoding with `cobs_encode_inc_end`.
+The incremental encoding API lets you stream COBS-encoded data through small buffers. Each call to `cobs_encode_inc` takes per-call source and destination buffers, reporting how many bytes were consumed and written. A 255-byte work buffer (provided by the caller) holds the current in-progress block internally.
 
-```
+This is ideal for memory-constrained embedded systems that can't allocate `COBS_ENCODE_MAX(n)` bytes up front.
+
+```c
+unsigned char work_buf[255];       // user-provided, must remain valid until end()
 cobs_enc_ctx_t ctx;
-char encoded[128];
-cobs_ret_t r = cobs_encode_inc_begin(encoded, 128, &ctx);
-if (r != COBS_RET_SUCCESS) { /* handle the error */ }
+cobs_ret_t r = cobs_encode_inc_begin(&ctx, work_buf, sizeof(work_buf));
 
-char header[8];
-unsigned const header_len = get_header_from_somewhere(header);
-r = cobs_encode_inc(&ctx, header, header_len); // encode the header
-if (r != COBS_RET_SUCCESS) { /* handle the error */ }
+unsigned char header[8];
+unsigned header_len = get_header(header);
 
-char const *payload;
-unsigned const payload_len = get_payload_from_somewhere(&payload);
-r = cobs_encode_inc(&ctx, payload, payload_len); // encode the payload
-if (r != COBS_RET_SUCCESS) { /* handle the error */ }
+unsigned char out[64];             // small output buffer, reused each call
+size_t src_consumed, dst_written;
 
-unsigned encoded_len;
-r = cobs_encode_inc_end(&ctx, &encoded_len);
-if (r != COBS_RET_SUCCESS) { /* handle your error, return / assert, whatever */ }
+cobs_encode_inc_args_t args;
+args.dec_src = header;
+args.enc_dst = out;
+args.dec_src_max = header_len;
+args.enc_dst_max = sizeof(out);
+r = cobs_encode_inc(&ctx, &args, &src_consumed, &dst_written);
+// send out[0..dst_written) downstream
 
-/* At this point, |encoded| contains the encoded header and payload.
-   |encoded_len| contains the length of the encoded buffer. */
+unsigned char const *payload;
+unsigned payload_len = get_payload(&payload);
+
+// Feed payload in chunks; small output buffers are fine
+size_t pos = 0;
+while (pos < payload_len) {
+  args.dec_src = payload + pos;
+  args.enc_dst = out;
+  args.dec_src_max = payload_len - pos;
+  args.enc_dst_max = sizeof(out);
+  r = cobs_encode_inc(&ctx, &args, &src_consumed, &dst_written);
+  // send out[0..dst_written) downstream
+  pos += src_consumed;
+}
+
+// Flush the final block + delimiter (may need multiple calls with tiny buffers)
+bool finished = false;
+while (!finished) {
+  r = cobs_encode_inc_end(&ctx, out, sizeof(out), &dst_written, &finished);
+  // send out[0..dst_written) downstream
+}
 ```
 
-### Encoding "Tiny Frames"
+If your output buffer is large enough (e.g. `COBS_ENCODE_MAX(n)` bytes), each call consumes all source bytes and `end()` finishes in one call. With smaller output buffers, the encoder pauses mid-flush and resumes on the next call.
 
-If you can guarantee that your payloads are shorter than 254 bytes, then you can use the "tinyframe" API, which lets you both decode and encode in-place in a single buffer. The COBS protocol requires an extra byte at the beginning and end of the payload. If encoding and decoding in-place, it becomes your responsibility to reserve these extra bytes. It's easy to mess this up and just put your own data at byte 0, but your data must start at byte 1. For safety and sanity, `cobs_encode_tinyframe` will error with `COBS_RET_ERR_BAD_PAYLOAD` if the first and last bytes aren't explicitly set to the sentinel value. You have to put them there.
+### Incremental Decoding
+
+The incremental decoding API mirrors the encoding API. Each call to `cobs_decode_inc` takes per-call source and destination buffers, reporting how many encoded bytes were consumed, how many decoded bytes were written, and whether the frame delimiter has been reached.
+
+```c
+cobs_decode_inc_ctx_t ctx;
+cobs_ret_t r = cobs_decode_inc_begin(&ctx);
+
+unsigned char enc[64];             // small input buffer, filled from uart/etc
+unsigned char dec[64];             // small output buffer
+size_t src_consumed, dst_written;
+bool complete = false;
+
+while (!complete) {
+  unsigned enc_len = read_encoded_chunk(enc, sizeof(enc));
+
+  cobs_decode_inc_args_t args;
+  args.enc_src = enc;
+  args.dec_dst = dec;
+  args.enc_src_max = enc_len;
+  args.dec_dst_max = sizeof(dec);
+  r = cobs_decode_inc(&ctx, &args, &src_consumed, &dst_written, &complete);
+  // process dec[0..dst_written) upstream
+}
+```
+
+### Tinyframe Encoding
+
+If you can guarantee that your payloads are shorter than 254 bytes, you can use the tinyframe API to encode and decode in-place in a single buffer. The COBS protocol requires an extra byte at the beginning and end of the payload. If encoding and decoding in-place, it becomes your responsibility to reserve these extra bytes. It's easy to mess this up and just put your own data at byte 0, but your data must start at byte 1. For safety and sanity, `cobs_encode_tinyframe` will error with `COBS_RET_ERR_BAD_PAYLOAD` if the first and last bytes aren't explicitly set to the sentinel value. You have to put them there.
 
 (Note that `64` is an arbitrary size in this example, you can use any size you want up to `COBS_TINYFRAME_SAFE_BUFFER_SIZE`)
 
-```
+```c
 char buf[64];
 buf[0] = COBS_TINYFRAME_SENTINEL_VALUE; // You have to do this.
 buf[63] = COBS_TINYFRAME_SENTINEL_VALUE; // You have to do this.
@@ -131,13 +182,14 @@ if (result == COBS_RET_SUCCESS) {
   // encoding failed, look to 'result' for details.
 }
 ```
-### Decoding "Tiny Frames"
 
-`cobs_decode_tinyframe` is also provided and offers byte-layout-parity to `cobs_encode_tinyframe`. This lets you, for example, decode a payload, change some bytes, and re-encode it all in the same buffer:
+### Tinyframe Decoding
 
-Accumulate data from your source until you encounter a COBS frame delimiter byte of `0x00`. Once you've got that, call `cobs_decode_inplace` on that region of a buffer to do an in-place decoding. The zeroth and final bytes of your payload will be replaced with the `COBS_TINYFRAME_SENTINEL_VALUE` bytes that, were you _encoding_ in-place, you would have had to place there anyway.
+`cobs_decode_tinyframe` offers byte-layout-parity with `cobs_encode_tinyframe`. This lets you decode a payload, change some bytes, and re-encode it all in the same buffer.
 
-```
+Accumulate data from your source until you encounter a COBS frame delimiter byte of `0x00`. Once you've got that, call `cobs_decode_tinyframe` on that region of a buffer to do an in-place decoding. The zeroth and final bytes of your payload will be replaced with the `COBS_TINYFRAME_SENTINEL_VALUE` bytes that, were you _encoding_ in-place, you would have had to place there anyway.
+
+```c
 char buf[64];
 
 // You fill 'buf' with an encoded cobs frame (from uart, etc) that ends with 0x00.

--- a/cobs.c
+++ b/cobs.c
@@ -3,8 +3,6 @@
 
 #define COBS_TFSV COBS_TINYFRAME_SENTINEL_VALUE
 
-typedef unsigned char cobs_byte_t;
-
 cobs_ret_t cobs_encode_tinyframe(void* buf, size_t len) {
   if (!buf || (len < 2)) {
     return COBS_RET_ERR_BAD_ARG;
@@ -69,109 +67,218 @@ cobs_ret_t cobs_encode(void const* dec,
                        void* out_enc,
                        size_t enc_max,
                        size_t* out_enc_len) {
-  if (!out_enc_len) {
-    return COBS_RET_ERR_BAD_ARG;
-  }
-
-  cobs_enc_ctx_t ctx;
-  cobs_ret_t r;
-  if ((r = cobs_encode_inc_begin(out_enc, enc_max, &ctx)) != COBS_RET_SUCCESS) {
-    return r;
-  }
-  if ((r = cobs_encode_inc(&ctx, dec, dec_len)) != COBS_RET_SUCCESS) {
-    return r;
-  }
-  return cobs_encode_inc_end(&ctx, out_enc_len);
-}
-
-cobs_ret_t cobs_encode_inc_begin(void* out_enc, size_t enc_max, cobs_enc_ctx_t* out_ctx) {
-  if (!out_enc || !out_ctx) {
+  if (!dec || !out_enc || !out_enc_len) {
     return COBS_RET_ERR_BAD_ARG;
   }
   if (enc_max < 2) {
     return COBS_RET_ERR_BAD_ARG;
   }
 
-  out_ctx->dst = out_enc;
-  out_ctx->dst_max = enc_max;
-  out_ctx->cur = 1;
-  out_ctx->code = 1;
-  out_ctx->code_idx = 0;
-  out_ctx->need_advance = 0;
-  return COBS_RET_SUCCESS;
-}
-
-cobs_ret_t cobs_encode_inc(cobs_enc_ctx_t* ctx, void const* dec, size_t dec_len) {
-  if (!ctx || !dec) {
-    return COBS_RET_ERR_BAD_ARG;
-  }
-  size_t dst_idx = ctx->cur;
-  size_t const enc_max = ctx->dst_max;
-  if ((enc_max - dst_idx) < dec_len) {
-    return COBS_RET_ERR_EXHAUSTED;
-  }
-  if (!dec_len) {
-    return COBS_RET_SUCCESS;
-  }
-
-  size_t dst_code_idx = ctx->code_idx;
-  unsigned code = ctx->code;
-  int need_advance = ctx->need_advance;
-
   cobs_byte_t const* const src = (cobs_byte_t const*)dec;
-  cobs_byte_t* const dst = (cobs_byte_t*)ctx->dst;
-  size_t src_idx = 0;
+  cobs_byte_t* const dst = (cobs_byte_t*)out_enc;
 
-  if (need_advance) {
-    if (++dst_idx >= enc_max) {
+  size_t src_idx = 0;
+  size_t dst_idx = 1;
+  size_t code_idx = 0;
+  unsigned code = 1;
+
+  while (src_idx < dec_len) {
+    if (dst_idx >= enc_max) {
       return COBS_RET_ERR_EXHAUSTED;
     }
-    need_advance = 0;
-  }
 
-  while (dec_len--) {
     cobs_byte_t const byte = src[src_idx];
     if (byte) {
       dst[dst_idx] = byte;
-      if (++dst_idx >= enc_max) {
-        return COBS_RET_ERR_EXHAUSTED;
-      }
+      ++dst_idx;
       ++code;
     }
 
     if ((byte == 0) || (code == 0xFF)) {
-      dst[dst_code_idx] = (cobs_byte_t)code;
-      dst_code_idx = dst_idx;
+      dst[code_idx] = (cobs_byte_t)code;
+      code_idx = dst_idx;
       code = 1;
 
-      if ((byte == 0) || dec_len) {
-        if (++dst_idx >= enc_max) {
-          return COBS_RET_ERR_EXHAUSTED;
-        }
-      } else {
-        need_advance = 1;
+      // Advance past code placeholder unless this is the last source byte
+      // AND code==0xFF. In that case, code_idx == dst_idx, and the final
+      // code byte will be overwritten by the delimiter (correct COBS).
+      if ((byte == 0) || (src_idx + 1 < dec_len)) {
+        ++dst_idx;
       }
     }
     ++src_idx;
   }
 
-  ctx->cur = dst_idx;
-  ctx->code = code;
-  ctx->code_idx = dst_code_idx;
-  ctx->need_advance = need_advance;
+  dst[code_idx] = (cobs_byte_t)code;
+  if (dst_idx >= enc_max) {
+    return COBS_RET_ERR_EXHAUSTED;
+  }
+  dst[dst_idx++] = COBS_FRAME_DELIMITER;
+  *out_enc_len = dst_idx;
   return COBS_RET_SUCCESS;
 }
 
-cobs_ret_t cobs_encode_inc_end(cobs_enc_ctx_t* ctx, size_t* out_enc_len) {
-  if (!ctx || !out_enc_len) {
+cobs_ret_t cobs_encode_inc_begin(cobs_enc_ctx_t* ctx, void* buf, size_t buf_max) {
+  if (!ctx || !buf) {
+    return COBS_RET_ERR_BAD_ARG;
+  }
+  if (buf_max < 255) {
     return COBS_RET_ERR_BAD_ARG;
   }
 
-  cobs_byte_t* const dst = (cobs_byte_t*)ctx->dst;
-  size_t cur = ctx->cur;
-  dst[ctx->code_idx] = (cobs_byte_t)ctx->code;
-  dst[cur++] = COBS_FRAME_DELIMITER;
-  *out_enc_len = cur;
+  ctx->state = COBS_ENCODE_ACCUMULATE;
+  ctx->buf = (cobs_byte_t*)buf;
+  ctx->code = 1;
+  ctx->buf_len = 1;
+  ctx->flush_pos = 0;
+  ctx->prev_was_ff = 0;
+  return COBS_RET_SUCCESS;
+}
+
+static inline size_t flush_block(cobs_enc_ctx_t* ctx, cobs_byte_t* dst, size_t dst_max) {
+  unsigned pos = ctx->flush_pos;
+  unsigned const len = ctx->buf_len;
+  cobs_byte_t const* const buf = ctx->buf;
+  size_t written = 0;
+  while ((pos < len) && (written < dst_max)) {
+    dst[written++] = buf[pos++];
+  }
+  ctx->flush_pos = (uint8_t)pos;
+  return written;
+}
+
+cobs_ret_t cobs_encode_inc(cobs_enc_ctx_t* ctx,
+                           cobs_encode_inc_args_t const* args,
+                           size_t* out_dec_src_len,
+                           size_t* out_enc_dst_len) {
+  if (!ctx || !args || !out_dec_src_len || !out_enc_dst_len || !args->dec_src ||
+      !args->enc_dst) {
+    return COBS_RET_ERR_BAD_ARG;
+  }
+
+  if (ctx->state >= COBS_ENCODE_FLUSH_FINAL) {
+    return COBS_RET_ERR_BAD_ARG;
+  }
+
+  cobs_byte_t const* const src = (cobs_byte_t const*)args->dec_src;
+  cobs_byte_t* const dst = (cobs_byte_t*)args->enc_dst;
+  size_t const src_max = args->dec_src_max;
+  size_t const dst_max = args->enc_dst_max;
+  size_t src_idx = 0;
+  size_t dst_idx = 0;
+
+  cobs_byte_t* const buf = ctx->buf;
+  unsigned code = ctx->code;
+  unsigned buf_len = ctx->buf_len;
+  enum cobs_encode_inc_state state = ctx->state;
+
+  for (;;) {
+    if (state == COBS_ENCODE_FLUSHING) {
+      ctx->buf_len = (uint8_t)buf_len;
+      dst_idx += flush_block(ctx, dst + dst_idx, dst_max - dst_idx);
+      if (ctx->flush_pos < buf_len) {
+        goto done;
+      }
+      state = COBS_ENCODE_ACCUMULATE;
+      code = 1;
+      buf_len = 1;
+      ctx->flush_pos = 0;
+    }
+
+    if (src_idx >= src_max) {
+      goto done;
+    }
+
+    cobs_byte_t const byte = src[src_idx];
+    if (byte) {
+      buf[buf_len++] = byte;
+      ++code;
+    }
+
+    if ((byte == 0) || (code == 0xFF)) {
+      ctx->prev_was_ff = (code == 0xFF);
+      buf[0] = (cobs_byte_t)code;
+      ctx->flush_pos = 0;
+      state = COBS_ENCODE_FLUSHING;
+    }
+
+    ++src_idx;
+  }
+
+done:
+  ctx->state = state;
+  ctx->code = (uint8_t)code;
+  ctx->buf_len = (uint8_t)buf_len;
+  *out_dec_src_len = src_idx;
+  *out_enc_dst_len = dst_idx;
+  return COBS_RET_SUCCESS;
+}
+
+cobs_ret_t cobs_encode_inc_end(cobs_enc_ctx_t* ctx,
+                               void* enc_dst,
+                               size_t enc_dst_max,
+                               size_t* out_enc_dst_len,
+                               bool* out_finished) {
+  if (!ctx || !enc_dst || !out_enc_dst_len || !out_finished) {
+    return COBS_RET_ERR_BAD_ARG;
+  }
+
+  cobs_byte_t* const dst = (cobs_byte_t*)enc_dst;
+  size_t dst_idx = 0;
+  enum cobs_encode_inc_state state = ctx->state;
+
+  for (;;) {
+    switch (state) {
+      case COBS_ENCODE_FLUSHING: {
+        dst_idx += flush_block(ctx, dst + dst_idx, enc_dst_max - dst_idx);
+        if (ctx->flush_pos < ctx->buf_len) {
+          goto done;
+        }
+        state = COBS_ENCODE_ACCUMULATE;
+        ctx->code = 1;
+        ctx->buf_len = 1;
+        ctx->flush_pos = 0;
+      } break;
+
+      case COBS_ENCODE_ACCUMULATE: {
+        // If the previous block was 0xFF and no new data accumulated (code==1,
+        // buf_len==1), skip the redundant trailing code byte — the delimiter
+        // directly follows the 0xFF block, matching standalone cobs_encode().
+        if (ctx->prev_was_ff && (ctx->code == 1) && (ctx->buf_len == 1)) {
+          state = COBS_ENCODE_WRITE_DELIM;
+        } else {
+          ctx->buf[0] = (cobs_byte_t)ctx->code;
+          ctx->flush_pos = 0;
+          state = COBS_ENCODE_FLUSH_FINAL;
+        }
+      } break;
+
+      case COBS_ENCODE_FLUSH_FINAL: {
+        dst_idx += flush_block(ctx, dst + dst_idx, enc_dst_max - dst_idx);
+        if (ctx->flush_pos < ctx->buf_len) {
+          goto done;
+        }
+        state = COBS_ENCODE_WRITE_DELIM;
+      } break;
+
+      case COBS_ENCODE_WRITE_DELIM: {
+        if (dst_idx >= enc_dst_max) {
+          goto done;
+        }
+        dst[dst_idx++] = COBS_FRAME_DELIMITER;
+        state = COBS_ENCODE_DONE;
+      } break;
+
+      case COBS_ENCODE_DONE: {
+        goto done;
+      }
+    }
+  }
+
+done:
+  ctx->state = state;
+  *out_enc_dst_len = dst_idx;
+  *out_finished = (state == COBS_ENCODE_DONE);
   return COBS_RET_SUCCESS;
 }
 

--- a/tests/test_cobs_encode.cc
+++ b/tests/test_cobs_encode.cc
@@ -37,7 +37,8 @@ byte_vec_t decode(byte_vec_t const& enc) {
 }  // namespace
 
 TEST_CASE("Encoding validation") {
-  byte_t enc[32], dec[32];
+  byte_t enc[32], dec[32]{};
+
   size_t constexpr enc_n{ sizeof(enc) };
   size_t constexpr dec_n{ sizeof(dec) };
   size_t enc_len;

--- a/tests/test_cobs_encode_inc.cc
+++ b/tests/test_cobs_encode_inc.cc
@@ -4,170 +4,678 @@
 
 #include <algorithm>
 #include <numeric>
+#include <random>
 
 TEST_CASE("cobs_encode_inc_begin") {
-  cobs_enc_ctx_t ctx;
-  byte_vec_t buf(1024);
+  cobs_enc_ctx_t ctx{};
+  byte_vec_t work_buf(255);
 
   SUBCASE("bad args") {
-    REQUIRE(cobs_encode_inc_begin(nullptr, buf.size(), &ctx) == COBS_RET_ERR_BAD_ARG);
-    REQUIRE(cobs_encode_inc_begin(buf.data(), 0, &ctx) == COBS_RET_ERR_BAD_ARG);
-    REQUIRE(cobs_encode_inc_begin(buf.data(), 1, &ctx) == COBS_RET_ERR_BAD_ARG);
-    REQUIRE(cobs_encode_inc_begin(buf.data(), 2, nullptr) == COBS_RET_ERR_BAD_ARG);
+    REQUIRE(cobs_encode_inc_begin(nullptr, work_buf.data(), work_buf.size()) ==
+            COBS_RET_ERR_BAD_ARG);
+    REQUIRE(cobs_encode_inc_begin(&ctx, nullptr, 255) == COBS_RET_ERR_BAD_ARG);
+    REQUIRE(cobs_encode_inc_begin(&ctx, work_buf.data(), 254) == COBS_RET_ERR_BAD_ARG);
+    REQUIRE(cobs_encode_inc_begin(&ctx, work_buf.data(), 0) == COBS_RET_ERR_BAD_ARG);
   }
 
-  SUBCASE("enc_max of 2 succeeds") {
-    REQUIRE(cobs_encode_inc_begin(buf.data(), 2, &ctx) == COBS_RET_SUCCESS);
+  SUBCASE("buf_len of 255 succeeds") {
+    REQUIRE(cobs_encode_inc_begin(&ctx, work_buf.data(), 255) == COBS_RET_SUCCESS);
   }
 
   SUBCASE("initializes context") {
-    ctx.cur = 123;
-    ctx.code_idx = 456;
-    ctx.code = 789;
-    ctx.need_advance = 1;
-    REQUIRE(cobs_encode_inc_begin(buf.data(), buf.size(), &ctx) == COBS_RET_SUCCESS);
-    REQUIRE(ctx.dst == buf.data());
-    REQUIRE(ctx.dst_max == buf.size());
-    REQUIRE(ctx.cur == 1);
+    ctx.code = 123;
+    ctx.buf_len = 99;
+    ctx.flush_pos = 42;
+    REQUIRE(cobs_encode_inc_begin(&ctx, work_buf.data(), work_buf.size()) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_ACCUMULATE);
+    REQUIRE(ctx.buf == work_buf.data());
     REQUIRE(ctx.code == 1);
-    REQUIRE(ctx.code_idx == 0);
-    REQUIRE(ctx.need_advance == 0);
+    REQUIRE(ctx.buf_len == 1);
+    REQUIRE(ctx.flush_pos == 0);
   }
 }
 
 TEST_CASE("cobs_encode_inc") {
   cobs_enc_ctx_t ctx{};
-  size_t constexpr enc_max{ 1024 };
-  byte_vec_t enc_buf(enc_max);
-  size_t constexpr dec_max{ 1024 };
-  byte_vec_t dec_buf(dec_max);
-
-  REQUIRE(cobs_encode_inc_begin(enc_buf.data(), enc_max, &ctx) == COBS_RET_SUCCESS);
+  byte_vec_t work_buf(255);
+  byte_vec_t enc_buf(1024);
+  byte_vec_t dec_buf(1024);
+  REQUIRE(cobs_encode_inc_begin(&ctx, work_buf.data(), work_buf.size()) ==
+          COBS_RET_SUCCESS);
 
   SUBCASE("bad args") {
-    REQUIRE(cobs_encode_inc(nullptr, dec_buf.data(), 16) == COBS_RET_ERR_BAD_ARG);
-    REQUIRE(cobs_encode_inc(&ctx, nullptr, 16) == COBS_RET_ERR_BAD_ARG);
+    size_t src_len{}, dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 16;
+    args.enc_dst_max = 16;
+
+    REQUIRE(cobs_encode_inc(nullptr, &args, &src_len, &dst_len) == COBS_RET_ERR_BAD_ARG);
+    REQUIRE(cobs_encode_inc(&ctx, nullptr, &src_len, &dst_len) == COBS_RET_ERR_BAD_ARG);
+    REQUIRE(cobs_encode_inc(&ctx, &args, nullptr, &dst_len) == COBS_RET_ERR_BAD_ARG);
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, nullptr) == COBS_RET_ERR_BAD_ARG);
+
+    cobs_encode_inc_args_t bad_args{};
+    bad_args.dec_src = nullptr;
+    bad_args.enc_dst = enc_buf.data();
+    bad_args.dec_src_max = 16;
+    bad_args.enc_dst_max = 16;
+    REQUIRE(cobs_encode_inc(&ctx, &bad_args, &src_len, &dst_len) == COBS_RET_ERR_BAD_ARG);
+
+    bad_args.dec_src = dec_buf.data();
+    bad_args.enc_dst = nullptr;
+    REQUIRE(cobs_encode_inc(&ctx, &bad_args, &src_len, &dst_len) == COBS_RET_ERR_BAD_ARG);
   }
 
-  SUBCASE("zero-byte write") {
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 0) == COBS_RET_SUCCESS);
-    ctx.cur = ctx.dst_max - 1;
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 0) == COBS_RET_SUCCESS);
+  SUBCASE("zero-length source consumes nothing") {
+    size_t src_len{}, dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 0;
+    args.enc_dst_max = 1024;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(src_len == 0);
+    REQUIRE(dst_len == 0);
   }
 
-  SUBCASE("exhausted") {
-    ctx.cur = ctx.dst_max - 1;
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 1) == COBS_RET_ERR_EXHAUSTED);
-    ctx.cur = ctx.dst_max - 2;
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 2) == COBS_RET_ERR_EXHAUSTED);
-    ctx.cur = 0;
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), ctx.dst_max) == COBS_RET_ERR_EXHAUSTED);
-  }
-
-  SUBCASE("accumulates nonzero bytes into buffer") {
+  SUBCASE("accumulates nonzero bytes without flushing") {
     dec_buf[0] = 0x12;
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 1) == COBS_RET_SUCCESS);
+    dec_buf[1] = 0x34;
+    dec_buf[2] = 0x56;
+    size_t src_len{}, dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 3;
+    args.enc_dst_max = 1024;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(src_len == 3);
+    REQUIRE(dst_len == 0);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_ACCUMULATE);
+    REQUIRE(ctx.code == 4);
+    REQUIRE(ctx.buf_len == 4);
+  }
+
+  SUBCASE("flushes block on zero byte") {
+    dec_buf[0] = 0x12;
+    dec_buf[1] = 0x00;
+    size_t src_len{}, dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 2;
+    args.enc_dst_max = 1024;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(src_len == 2);
+    REQUIRE(dst_len == 2);
+    REQUIRE(enc_buf[0] == 0x02);
     REQUIRE(enc_buf[1] == 0x12);
-
-    for (byte_t i{ 0 }; i < 10; ++i) {
-      dec_buf[i] = i;
-    }
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 10) == COBS_RET_SUCCESS);
-    for (byte_t i{ 0 }; i < 10; ++i) {
-      REQUIRE(enc_buf[2 + i] == i);
-    }
-  }
-
-  SUBCASE("advances cursor with every byte written") {
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 1) == COBS_RET_SUCCESS);
-    REQUIRE(ctx.cur == 2);
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 12) == COBS_RET_SUCCESS);
-    REQUIRE(ctx.cur == 14);
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 37) == COBS_RET_SUCCESS);
-    REQUIRE(ctx.cur == 51);
-  }
-
-  SUBCASE("Nonzero bytes increment code") {
-    std::fill(std::begin(dec_buf), std::end(dec_buf), byte_t{ 1 });
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 1) == COBS_RET_SUCCESS);
-    REQUIRE(ctx.code == 2);
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 13) == COBS_RET_SUCCESS);
-    REQUIRE(ctx.code == 15);
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 59) == COBS_RET_SUCCESS);
-    REQUIRE(ctx.code == 74);
-  }
-
-  SUBCASE("Encoding a zero byte writes and resets the code") {
-    ctx.code = 23;
-    dec_buf[0] = 0;
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 1) == COBS_RET_SUCCESS);
-    REQUIRE(enc_buf[0] == 23);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_ACCUMULATE);
     REQUIRE(ctx.code == 1);
+    REQUIRE(ctx.buf_len == 1);
+    REQUIRE(ctx.prev_was_ff == 0);
   }
 
-  SUBCASE("Encoding the 255th non-zero byte writes + resets the code") {
-    ctx.code = 254;
-    dec_buf[0] = 1;
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 1) == COBS_RET_SUCCESS);
-    REQUIRE(enc_buf[0] == 255);
+  SUBCASE("flushes block at 0xFF boundary") {
+    std::fill(dec_buf.begin(), dec_buf.begin() + 254, byte_t{ 0x01 });
+    size_t src_len{}, dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 254;
+    args.enc_dst_max = 1024;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(src_len == 254);
+    REQUIRE(dst_len == 255);
+    REQUIRE(enc_buf[0] == 0xFF);
+    for (size_t i = 1; i < 255; ++i) {
+      REQUIRE(enc_buf[i] == 0x01);
+    }
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_ACCUMULATE);
     REQUIRE(ctx.code == 1);
+    REQUIRE(ctx.buf_len == 1);
+    REQUIRE(ctx.prev_was_ff == 1);
   }
 
-  SUBCASE("Remembers the need to advance when final src byte is 255th nonzero") {
-    ctx.code = 254;
-    dec_buf[0] = 1;
-    ctx.need_advance = 0;
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 1) == COBS_RET_SUCCESS);
-    REQUIRE(ctx.need_advance == 1);
+  SUBCASE("prev_was_ff cleared by non-0xFF block") {
+    // 254 nonzero bytes → 0xFF block, then a zero byte → non-0xFF block
+    std::fill(dec_buf.begin(), dec_buf.begin() + 254, byte_t{ 0x01 });
+    dec_buf[254] = 0x00;
+    size_t src_len{}, dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 255;
+    args.enc_dst_max = 1024;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(ctx.prev_was_ff == 0);
   }
 
-  SUBCASE("Advances the cursor before additional encoding when flagged") {
-    ctx.need_advance = 1;
-    ctx.cur = 12;
-    dec_buf[0] = 234;
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), 1) == COBS_RET_SUCCESS);
-    REQUIRE(ctx.need_advance == 0);
-    REQUIRE(enc_buf[13] == 234);
+  SUBCASE("rejects calls after end (DONE state)") {
+    size_t dst_len{};
+    bool finished{};
+    REQUIRE(
+        cobs_encode_inc_end(&ctx, enc_buf.data(), enc_buf.size(), &dst_len, &finished) ==
+        COBS_RET_SUCCESS);
+    REQUIRE(finished);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_DONE);
+
+    size_t src_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 1;
+    args.enc_dst_max = 1024;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_ERR_BAD_ARG);
+  }
+
+  SUBCASE("rejects calls in FLUSH_FINAL state") {
+    // Transition to FLUSH_FINAL via end() with zero output
+    REQUIRE(cobs_encode_inc_end(&ctx, enc_buf.data(), 0, nullptr, nullptr) !=
+            COBS_RET_SUCCESS);  // bad arg (nullptr), but let's do it properly:
+    size_t dst_len{};
+    bool finished{};
+    REQUIRE(cobs_encode_inc_end(&ctx, enc_buf.data(), 0, &dst_len, &finished) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(!finished);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_FLUSH_FINAL);
+
+    size_t src_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 1;
+    args.enc_dst_max = 1024;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_ERR_BAD_ARG);
+  }
+
+  SUBCASE("rejects calls in WRITE_DELIM state") {
+    // Transition to WRITE_DELIM: end() with enough room for final code but not delimiter
+    size_t dst_len{};
+    bool finished{};
+    REQUIRE(cobs_encode_inc_end(&ctx, enc_buf.data(), 1, &dst_len, &finished) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(!finished);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_WRITE_DELIM);
+
+    size_t src_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 1;
+    args.enc_dst_max = 1024;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_ERR_BAD_ARG);
+  }
+
+  SUBCASE("partial flush when output buffer is small") {
+    dec_buf[0] = 0x12;
+    dec_buf[1] = 0x00;
+    size_t src_len{}, dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 2;
+    args.enc_dst_max = 1;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(src_len == 2);
+    REQUIRE(dst_len == 1);
+    REQUIRE(enc_buf[0] == 0x02);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_FLUSHING);
+
+    // Continue flushing with another call
+    cobs_encode_inc_args_t args2{};
+    args2.dec_src = dec_buf.data();
+    args2.enc_dst = enc_buf.data() + 1;
+    args2.dec_src_max = 0;
+    args2.enc_dst_max = 1;
+    REQUIRE(cobs_encode_inc(&ctx, &args2, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(dst_len == 1);
+    REQUIRE(enc_buf[1] == 0x12);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_ACCUMULATE);
+  }
+
+  SUBCASE("flush completes then accumulates more source in same call") {
+    // Trigger a block [0x12, 0x00], partially flush (1 of 2 bytes)
+    dec_buf[0] = 0x12;
+    dec_buf[1] = 0x00;
+    size_t src_len{}, dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 2;
+    args.enc_dst_max = 1;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_FLUSHING);
+
+    // Now call with output room AND new source — should finish flush then consume source
+    dec_buf[0] = 0x34;
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data() + 1;
+    args.dec_src_max = 1;
+    args.enc_dst_max = 10;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(src_len == 1);        // source byte consumed
+    REQUIRE(dst_len == 1);        // remaining flush byte written
+    REQUIRE(enc_buf[1] == 0x12);  // flushed data byte
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_ACCUMULATE);
+    REQUIRE(ctx.code == 2);  // 0x34 accumulated
+    REQUIRE(ctx.buf_len == 2);
+  }
+
+  SUBCASE("zero output space accumulates without flushing") {
+    dec_buf[0] = 0x12;
+    dec_buf[1] = 0x34;
+    size_t src_len{}, dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 2;
+    args.enc_dst_max = 0;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(src_len == 2);
+    REQUIRE(dst_len == 0);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_ACCUMULATE);
+    REQUIRE(ctx.code == 3);
+    REQUIRE(ctx.buf_len == 3);
+  }
+
+  SUBCASE("zero output space with block completion queues flush") {
+    dec_buf[0] = 0x12;
+    dec_buf[1] = 0x00;
+    dec_buf[2] = 0x34;  // should NOT be consumed
+    size_t src_len{}, dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 3;
+    args.enc_dst_max = 0;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(src_len == 2);  // consumed up to and including the zero
+    REQUIRE(dst_len == 0);  // no output (couldn't flush)
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_FLUSHING);
+    REQUIRE(ctx.flush_pos == 0);  // nothing flushed yet
+  }
+
+  SUBCASE("multiple blocks flushed in single call") {
+    // [0x11, 0x00, 0x22, 0x00] = two blocks in one call
+    dec_buf[0] = 0x11;
+    dec_buf[1] = 0x00;
+    dec_buf[2] = 0x22;
+    dec_buf[3] = 0x00;
+    size_t src_len{}, dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec_buf.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 4;
+    args.enc_dst_max = 1024;
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(src_len == 4);
+    REQUIRE(dst_len == 4);  // block1: [0x02, 0x11], block2: [0x02, 0x22]
+    REQUIRE(enc_buf[0] == 0x02);
+    REQUIRE(enc_buf[1] == 0x11);
+    REQUIRE(enc_buf[2] == 0x02);
+    REQUIRE(enc_buf[3] == 0x22);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_ACCUMULATE);
   }
 }
 
 TEST_CASE("cobs_encode_inc_end") {
   cobs_enc_ctx_t ctx{};
-  size_t constexpr enc_max{ 1024 };
-  byte_vec_t enc_buf(enc_max);
-  size_t enc_len{ 0 };
+  byte_vec_t work_buf(255);
+  byte_vec_t enc_buf(1024);
+  size_t dst_len{};
+  bool finished{};
 
-  REQUIRE(cobs_encode_inc_begin(enc_buf.data(), enc_max, &ctx) == COBS_RET_SUCCESS);
+  REQUIRE(cobs_encode_inc_begin(&ctx, work_buf.data(), work_buf.size()) ==
+          COBS_RET_SUCCESS);
 
   SUBCASE("bad args") {
-    REQUIRE(cobs_encode_inc_end(nullptr, &enc_len) == COBS_RET_ERR_BAD_ARG);
-    REQUIRE(cobs_encode_inc_end(&ctx, nullptr) == COBS_RET_ERR_BAD_ARG);
+    REQUIRE(cobs_encode_inc_end(nullptr,
+                                enc_buf.data(),
+                                enc_buf.size(),
+                                &dst_len,
+                                &finished) == COBS_RET_ERR_BAD_ARG);
+    REQUIRE(cobs_encode_inc_end(&ctx, nullptr, enc_buf.size(), &dst_len, &finished) ==
+            COBS_RET_ERR_BAD_ARG);
+    REQUIRE(
+        cobs_encode_inc_end(&ctx, enc_buf.data(), enc_buf.size(), nullptr, &finished) ==
+        COBS_RET_ERR_BAD_ARG);
+    REQUIRE(cobs_encode_inc_end(&ctx, enc_buf.data(), enc_buf.size(), &dst_len, nullptr) ==
+            COBS_RET_ERR_BAD_ARG);
   }
 
-  SUBCASE("Writes final code") {
-    ctx.code = 123;
-    ctx.code_idx = 7;
-    REQUIRE(cobs_encode_inc_end(&ctx, &enc_len) == COBS_RET_SUCCESS);
-    REQUIRE(enc_buf[ctx.code_idx] == ctx.code);
-  }
-
-  SUBCASE("Writes final frame delimiter") {
-    ctx.cur = 97;
-    enc_buf[97] = 0xFD;
-    REQUIRE(cobs_encode_inc_end(&ctx, &enc_len) == COBS_RET_SUCCESS);
-    REQUIRE(enc_buf[97] == 0);
-  }
-
-  SUBCASE("Encoded length is final cursor position") {
-    ctx.cur = 331;
-    REQUIRE(cobs_encode_inc_end(&ctx, &enc_len) == COBS_RET_SUCCESS);
-    REQUIRE(enc_len == 332);
-  }
-
-  SUBCASE("Empty payload produces valid frame") {
-    REQUIRE(cobs_encode_inc_end(&ctx, &enc_len) == COBS_RET_SUCCESS);
-    REQUIRE(enc_len == 2);
+  SUBCASE("empty payload produces valid frame") {
+    REQUIRE(
+        cobs_encode_inc_end(&ctx, enc_buf.data(), enc_buf.size(), &dst_len, &finished) ==
+        COBS_RET_SUCCESS);
+    REQUIRE(finished);
+    REQUIRE(dst_len == 2);
     REQUIRE(enc_buf[0] == 0x01);
+    REQUIRE(enc_buf[1] == 0x00);
+  }
+
+  SUBCASE("writes final code + data + delimiter") {
+    // Feed some nonzero bytes first
+    byte_vec_t dec{ 0x12, 0x34 };
+    size_t src_len{};
+    size_t inc_dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = dec.size();
+    args.enc_dst_max = enc_buf.size();
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &inc_dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(inc_dst_len == 0);
+
+    REQUIRE(
+        cobs_encode_inc_end(&ctx, enc_buf.data(), enc_buf.size(), &dst_len, &finished) ==
+        COBS_RET_SUCCESS);
+    REQUIRE(finished);
+    REQUIRE(dst_len == 4);
+    REQUIRE(enc_buf[0] == 0x03);
+    REQUIRE(enc_buf[1] == 0x12);
+    REQUIRE(enc_buf[2] == 0x34);
+    REQUIRE(enc_buf[3] == 0x00);
+  }
+
+  SUBCASE("end with 1-byte output buffer needs multiple calls") {
+    byte_vec_t dec{ 0xAA, 0xBB };
+    size_t src_len{};
+    size_t inc_dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = dec.size();
+    args.enc_dst_max = enc_buf.size();
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &inc_dst_len) == COBS_RET_SUCCESS);
+
+    // Flush with 1-byte output at a time
+    byte_vec_t result;
+    finished = false;
+    while (!finished) {
+      byte_t out_byte{};
+      REQUIRE(cobs_encode_inc_end(&ctx, &out_byte, 1, &dst_len, &finished) ==
+              COBS_RET_SUCCESS);
+      for (size_t i = 0; i < dst_len; ++i) {
+        result.push_back((&out_byte)[i]);
+      }
+    }
+    REQUIRE(result.size() == 4);
+    REQUIRE(result[0] == 0x03);
+    REQUIRE(result[1] == 0xAA);
+    REQUIRE(result[2] == 0xBB);
+    REQUIRE(result[3] == 0x00);
+  }
+
+  SUBCASE("zero-size output makes no progress") {
+    // Empty payload: ACCUMULATE → FLUSH_FINAL (buf=[0x01]), but 0 output room
+    REQUIRE(cobs_encode_inc_end(&ctx, enc_buf.data(), 0, &dst_len, &finished) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(dst_len == 0);
+    REQUIRE(!finished);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_FLUSH_FINAL);
+  }
+
+  SUBCASE("end state progression: ACCUMULATE to DONE") {
+    // Feed a byte so FLUSH_FINAL has something to flush
+    byte_vec_t dec{ 0x42 };
+    size_t src_len{}, inc_dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 1;
+    args.enc_dst_max = enc_buf.size();
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &inc_dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_ACCUMULATE);
+
+    // 1 byte output: ACCUMULATE → FLUSH_FINAL, flush 1 of 2 bytes
+    REQUIRE(cobs_encode_inc_end(&ctx, enc_buf.data(), 1, &dst_len, &finished) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(!finished);
+    REQUIRE(dst_len == 1);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_FLUSH_FINAL);
+
+    // 1 byte output: finish FLUSH_FINAL → WRITE_DELIM, no room for delimiter
+    REQUIRE(cobs_encode_inc_end(&ctx, enc_buf.data() + 1, 1, &dst_len, &finished) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(!finished);
+    REQUIRE(dst_len == 1);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_WRITE_DELIM);
+
+    // 1 byte output: write delimiter → DONE
+    REQUIRE(cobs_encode_inc_end(&ctx, enc_buf.data() + 2, 1, &dst_len, &finished) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(finished);
+    REQUIRE(dst_len == 1);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_DONE);
+    REQUIRE(enc_buf[0] == 0x02);
+    REQUIRE(enc_buf[1] == 0x42);
+    REQUIRE(enc_buf[2] == 0x00);
+  }
+
+  SUBCASE("DONE is sticky") {
+    REQUIRE(
+        cobs_encode_inc_end(&ctx, enc_buf.data(), enc_buf.size(), &dst_len, &finished) ==
+        COBS_RET_SUCCESS);
+    REQUIRE(finished);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_DONE);
+
+    // Repeated calls return finished with zero bytes written
+    REQUIRE(
+        cobs_encode_inc_end(&ctx, enc_buf.data(), enc_buf.size(), &dst_len, &finished) ==
+        COBS_RET_SUCCESS);
+    REQUIRE(finished);
+    REQUIRE(dst_len == 0);
+  }
+
+  SUBCASE("end picks up partial flush left by inc") {
+    // Create a block, flush partially via inc, then call end
+    byte_vec_t dec{ 0x11, 0x22, 0x00 };
+    size_t src_len{}, inc_dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = dec.size();
+    args.enc_dst_max = 1;  // only room for 1 byte
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &inc_dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_FLUSHING);
+
+    // end() should finish the flush, then finalize
+    byte_vec_t result(enc_buf.data(), enc_buf.data() + inc_dst_len);
+    finished = false;
+    while (!finished) {
+      byte_t out_byte{};
+      REQUIRE(cobs_encode_inc_end(&ctx, &out_byte, 1, &dst_len, &finished) ==
+              COBS_RET_SUCCESS);
+      for (size_t i = 0; i < dst_len; ++i) {
+        result.push_back((&out_byte)[i]);
+      }
+    }
+    // [0x11, 0x22, 0x00] encodes to [0x03, 0x11, 0x22, 0x01, 0x00]
+    REQUIRE(result.size() == 5);
+    REQUIRE(result[0] == 0x03);
+    REQUIRE(result[1] == 0x11);
+    REQUIRE(result[2] == 0x22);
+    REQUIRE(result[3] == 0x01);
+    REQUIRE(result[4] == 0x00);
+  }
+
+  SUBCASE("begin reinitializes a completed context") {
+    REQUIRE(
+        cobs_encode_inc_end(&ctx, enc_buf.data(), enc_buf.size(), &dst_len, &finished) ==
+        COBS_RET_SUCCESS);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_DONE);
+
+    // Reinitialize
+    REQUIRE(cobs_encode_inc_begin(&ctx, work_buf.data(), work_buf.size()) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_ACCUMULATE);
+    REQUIRE(ctx.code == 1);
+    REQUIRE(ctx.buf_len == 1);
+    REQUIRE(ctx.flush_pos == 0);
+    REQUIRE(ctx.prev_was_ff == 0);
+
+    // Should be fully functional again
+    REQUIRE(
+        cobs_encode_inc_end(&ctx, enc_buf.data(), enc_buf.size(), &dst_len, &finished) ==
+        COBS_RET_SUCCESS);
+    REQUIRE(finished);
+    REQUIRE(dst_len == 2);
+    REQUIRE(enc_buf[0] == 0x01);
+    REQUIRE(enc_buf[1] == 0x00);
+  }
+
+  SUBCASE("prev_was_ff shortcut skips FLUSH_FINAL") {
+    // Feed 254 nonzero bytes → 0xFF block flushes, prev_was_ff=1, code=1, buf_len=1
+    byte_vec_t dec(254, 0x01);
+    size_t src_len{}, inc_dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = dec.size();
+    args.enc_dst_max = enc_buf.size();
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &inc_dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(ctx.prev_was_ff == 1);
+    REQUIRE(ctx.code == 1);
+    REQUIRE(ctx.buf_len == 1);
+
+    // end() should skip FLUSH_FINAL and go directly to WRITE_DELIM → DONE
+    REQUIRE(
+        cobs_encode_inc_end(&ctx, enc_buf.data() + inc_dst_len, 1, &dst_len, &finished) ==
+        COBS_RET_SUCCESS);
+    REQUIRE(finished);
+    REQUIRE(dst_len == 1);
+    REQUIRE(enc_buf[inc_dst_len] == 0x00);  // delimiter only, no trailing code byte
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_DONE);
+  }
+
+  SUBCASE("prev_was_ff with accumulated data goes to FLUSH_FINAL") {
+    // Feed 254+3 nonzero bytes: 0xFF block, then 3 more accumulated
+    byte_vec_t dec(257, 0x01);
+    size_t src_len{}, inc_dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = dec.size();
+    args.enc_dst_max = enc_buf.size();
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &inc_dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(ctx.prev_was_ff == 1);
+    REQUIRE(ctx.code == 4);  // 3 bytes accumulated after 0xFF block
+    REQUIRE(ctx.buf_len == 4);
+
+    // end() should NOT take shortcut: code != 1, so goes to FLUSH_FINAL
+    REQUIRE(
+        cobs_encode_inc_end(&ctx, enc_buf.data() + inc_dst_len, 1, &dst_len, &finished) ==
+        COBS_RET_SUCCESS);
+    REQUIRE(!finished);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_FLUSH_FINAL);
+  }
+
+  SUBCASE("zero output in WRITE_DELIM makes no progress") {
+    // Get to WRITE_DELIM: end() empty payload with room for code byte but not delimiter
+    REQUIRE(cobs_encode_inc_end(&ctx, enc_buf.data(), 1, &dst_len, &finished) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(!finished);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_WRITE_DELIM);
+
+    // Now call with 0 output
+    REQUIRE(cobs_encode_inc_end(&ctx, enc_buf.data(), 0, &dst_len, &finished) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(!finished);
+    REQUIRE(dst_len == 0);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_WRITE_DELIM);
+  }
+
+  SUBCASE("zero output in FLUSHING makes no progress") {
+    // Get to FLUSHING via inc with partial flush
+    byte_vec_t dec{ 0x11, 0x00 };
+    size_t src_len{}, inc_dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = dec.size();
+    args.enc_dst_max = 0;  // can't flush at all
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &inc_dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_FLUSHING);
+
+    // end() with 0 output should make no progress
+    REQUIRE(cobs_encode_inc_end(&ctx, enc_buf.data(), 0, &dst_len, &finished) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(!finished);
+    REQUIRE(dst_len == 0);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_FLUSHING);
+  }
+
+  SUBCASE("FLUSHING completes then prev_was_ff shortcut fires") {
+    // Feed 254 nonzero, partially flush via inc
+    byte_vec_t dec(254, 0x01);
+    size_t src_len{}, inc_dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = dec.size();
+    args.enc_dst_max = 200;  // not enough for full 255-byte block
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &inc_dst_len) == COBS_RET_SUCCESS);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_FLUSHING);
+    REQUIRE(ctx.prev_was_ff == 1);
+
+    // end() with large output: FLUSHING → ACCUMULATE (prev_was_ff shortcut) → WRITE_DELIM
+    // → DONE
+    REQUIRE(cobs_encode_inc_end(&ctx,
+                                enc_buf.data() + inc_dst_len,
+                                enc_buf.size(),
+                                &dst_len,
+                                &finished) == COBS_RET_SUCCESS);
+    REQUIRE(finished);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_DONE);
+    // Output = remaining flush bytes + delimiter (no trailing code byte)
+    REQUIRE(enc_buf[inc_dst_len + dst_len - 1] == 0x00);
+  }
+
+  SUBCASE("resumed from FLUSH_FINAL completes") {
+    // Feed a byte, end() with 0 output → stuck in FLUSH_FINAL
+    byte_vec_t dec{ 0x42 };
+    size_t src_len{}, inc_dst_len{};
+    cobs_encode_inc_args_t args{};
+    args.dec_src = dec.data();
+    args.enc_dst = enc_buf.data();
+    args.dec_src_max = 1;
+    args.enc_dst_max = enc_buf.size();
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &inc_dst_len) == COBS_RET_SUCCESS);
+
+    REQUIRE(cobs_encode_inc_end(&ctx, enc_buf.data(), 0, &dst_len, &finished) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_FLUSH_FINAL);
+
+    // Resume with enough space
+    REQUIRE(
+        cobs_encode_inc_end(&ctx, enc_buf.data(), enc_buf.size(), &dst_len, &finished) ==
+        COBS_RET_SUCCESS);
+    REQUIRE(finished);
+    REQUIRE(dst_len == 3);  // code + data + delimiter
+    REQUIRE(enc_buf[0] == 0x02);
+    REQUIRE(enc_buf[1] == 0x42);
+    REQUIRE(enc_buf[2] == 0x00);
+  }
+
+  SUBCASE("resumed from WRITE_DELIM completes") {
+    // Get to WRITE_DELIM
+    REQUIRE(cobs_encode_inc_end(&ctx, enc_buf.data(), 1, &dst_len, &finished) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(ctx.state == cobs_enc_ctx_t::COBS_ENCODE_WRITE_DELIM);
+    REQUIRE(enc_buf[0] == 0x01);
+
+    // Resume — should write just the delimiter
+    REQUIRE(cobs_encode_inc_end(&ctx,
+                                enc_buf.data() + 1,
+                                enc_buf.size(),
+                                &dst_len,
+                                &finished) == COBS_RET_SUCCESS);
+    REQUIRE(finished);
+    REQUIRE(dst_len == 1);
     REQUIRE(enc_buf[1] == 0x00);
   }
 }
@@ -184,37 +692,83 @@ byte_vec_t encode_single(byte_vec_t const& dec) {
   return enc;
 }
 
-byte_vec_t encode_incremental(byte_vec_t const& decoded, size_t chunk_size) {
-  byte_vec_t encoded(COBS_ENCODE_MAX(decoded.size()));
+byte_vec_t encode_incremental(byte_vec_t const& decoded,
+                              size_t src_chunk,
+                              size_t dst_chunk) {
+  byte_vec_t work_buf(255);
+  cobs_enc_ctx_t ctx{};
+  REQUIRE(cobs_encode_inc_begin(&ctx, work_buf.data(), work_buf.size()) ==
+          COBS_RET_SUCCESS);
 
-  cobs_enc_ctx_t ctx;
-  REQUIRE(cobs_encode_inc_begin(encoded.data(), encoded.size(), &ctx) == COBS_RET_SUCCESS);
+  byte_vec_t result;
+  size_t src_pos = 0;
 
-  size_t cur = 0;
-  while (cur < decoded.size()) {
-    size_t const encode_size{ std::min(chunk_size, decoded.size() - cur) };
-    REQUIRE(cobs_encode_inc(&ctx, &decoded[cur], encode_size) == COBS_RET_SUCCESS);
-    cur += encode_size;
+  while (src_pos < decoded.size()) {
+    size_t const chunk = std::min(src_chunk, decoded.size() - src_pos);
+    byte_vec_t dst(dst_chunk);
+
+    cobs_encode_inc_args_t args{};
+    args.dec_src = decoded.data() + src_pos;
+    args.enc_dst = dst.data();
+    args.dec_src_max = chunk;
+    args.enc_dst_max = dst_chunk;
+
+    size_t src_consumed{}, dst_written{};
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_consumed, &dst_written) == COBS_RET_SUCCESS);
+    result.insert(result.end(), dst.data(), dst.data() + dst_written);
+    src_pos += src_consumed;
+
+    // If not all source was consumed, feed remaining with fresh output buffer
+    while (src_consumed < chunk) {
+      size_t remaining = chunk - src_consumed;
+      byte_vec_t dst2(dst_chunk);
+      cobs_encode_inc_args_t args2{};
+      args2.dec_src = decoded.data() + src_pos;
+      args2.enc_dst = dst2.data();
+      args2.dec_src_max = remaining;
+      args2.enc_dst_max = dst_chunk;
+
+      size_t sc2{}, dw2{};
+      REQUIRE(cobs_encode_inc(&ctx, &args2, &sc2, &dw2) == COBS_RET_SUCCESS);
+      result.insert(result.end(), dst2.data(), dst2.data() + dw2);
+      src_pos += sc2;
+      src_consumed += sc2;
+    }
   }
 
-  size_t len{ 0u };
-  REQUIRE(cobs_encode_inc_end(&ctx, &len) == COBS_RET_SUCCESS);
-  encoded.resize(len);
-  return encoded;
+  // end
+  bool finished = false;
+  while (!finished) {
+    byte_vec_t dst(dst_chunk);
+    size_t dst_written{};
+    REQUIRE(cobs_encode_inc_end(&ctx, dst.data(), dst_chunk, &dst_written, &finished) ==
+            COBS_RET_SUCCESS);
+    result.insert(result.end(), dst.data(), dst.data() + dst_written);
+  }
+
+  return result;
 }
 
 void verify_equivalence_all_chunks(byte_vec_t const& dec) {
   byte_vec_t const single = encode_single(dec);
-  for (size_t chunk : { size_t{ 1 },
-                        size_t{ 2 },
-                        size_t{ 3 },
-                        size_t{ 11 },
-                        size_t{ 127 },
-                        size_t{ 253 },
-                        size_t{ 254 },
-                        size_t{ 255 },
-                        size_t{ dec.size() + 1 } }) {
-    REQUIRE(encode_incremental(dec, chunk) == single);
+  for (size_t src_chunk : { size_t{ 1 },
+                            size_t{ 2 },
+                            size_t{ 3 },
+                            size_t{ 11 },
+                            size_t{ 127 },
+                            size_t{ 253 },
+                            size_t{ 254 },
+                            size_t{ 255 },
+                            size_t{ dec.size() + 1 } }) {
+    for (size_t dst_chunk : { size_t{ 1 },
+                              size_t{ 2 },
+                              size_t{ 3 },
+                              size_t{ 127 },
+                              size_t{ 255 },
+                              size_t{ 256 },
+                              size_t{ 1024 } }) {
+      REQUIRE(encode_incremental(dec, src_chunk, dst_chunk) == single);
+    }
   }
 }
 }  // namespace
@@ -289,13 +843,14 @@ TEST_CASE("Single/multi-encode equivalences") {
   }
 
   SUBCASE("Header / payload split") {
-    cobs_enc_ctx_t ctx;
-    size_t constexpr enc_max{ 4096 };
-    byte_vec_t enc_buf(enc_max);
+    byte_vec_t work_buf(255);
+    cobs_enc_ctx_t ctx{};
+    byte_vec_t enc_result;
 
-    REQUIRE(cobs_encode_inc_begin(enc_buf.data(), enc_max, &ctx) == COBS_RET_SUCCESS);
+    REQUIRE(cobs_encode_inc_begin(&ctx, work_buf.data(), work_buf.size()) ==
+            COBS_RET_SUCCESS);
 
-    byte_t constexpr h[]{ 0x02, 0x03, 0xCC, 0xDF, 0x13, 0x49 };
+    byte_t const h[]{ 0x02, 0x03, 0xCC, 0xDF, 0x13, 0x49 };
 
     byte_vec_t dec_buf(400);
     std::iota(std::begin(dec_buf), std::end(dec_buf), byte_t{ 0x01 });
@@ -304,17 +859,61 @@ TEST_CASE("Single/multi-encode equivalences") {
     dec_buf[45] = 0x00;
     dec_buf[68] = 0x00;
 
-    REQUIRE(cobs_encode_inc(&ctx, h, sizeof(h)) == COBS_RET_SUCCESS);
-    REQUIRE(cobs_encode_inc(&ctx, dec_buf.data(), dec_buf.size()) == COBS_RET_SUCCESS);
+    // Encode header
+    byte_vec_t dst(1024);
+    cobs_encode_inc_args_t args{};
+    args.dec_src = h;
+    args.enc_dst = dst.data();
+    args.dec_src_max = sizeof(h);
+    args.enc_dst_max = dst.size();
+    size_t src_len{}, dst_len{};
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    enc_result.insert(enc_result.end(), dst.data(), dst.data() + dst_len);
 
-    size_t len{ 0u };
-    REQUIRE(cobs_encode_inc_end(&ctx, &len) == COBS_RET_SUCCESS);
-    enc_buf.resize(len);
+    // Encode payload
+    args.dec_src = dec_buf.data();
+    args.enc_dst = dst.data();
+    args.dec_src_max = dec_buf.size();
+    args.enc_dst_max = dst.size();
+    REQUIRE(cobs_encode_inc(&ctx, &args, &src_len, &dst_len) == COBS_RET_SUCCESS);
+    enc_result.insert(enc_result.end(), dst.data(), dst.data() + dst_len);
+
+    // End
+    bool finished{};
+    REQUIRE(cobs_encode_inc_end(&ctx, dst.data(), dst.size(), &dst_len, &finished) ==
+            COBS_RET_SUCCESS);
+    REQUIRE(finished);
+    enc_result.insert(enc_result.end(), dst.data(), dst.data() + dst_len);
 
     byte_vec_t single_dec(h, h + sizeof(h));
     single_dec.insert(std::end(single_dec),
                       dec_buf.data(),
                       dec_buf.data() + dec_buf.size());
-    REQUIRE(enc_buf == encode_single(single_dec));
+    REQUIRE(enc_result == encode_single(single_dec));
+  }
+}
+
+TEST_CASE("Small buffer edge cases") {
+  SUBCASE("1-byte output buffer encodes correctly") {
+    byte_vec_t payload{ 0x11, 0x22, 0x33, 0x00, 0x44 };
+    REQUIRE(encode_incremental(payload, 1, 1) == encode_single(payload));
+  }
+
+  SUBCASE("Output buffer smaller than one block") {
+    byte_vec_t payload(100, 0x42);
+    REQUIRE(encode_incremental(payload, 100, 3) == encode_single(payload));
+  }
+
+  SUBCASE("Random chunk sizes") {
+    std::mt19937 mt{ 42u };
+    for (int iter = 0; iter < 100; ++iter) {
+      size_t const len = 1 + (mt() % 1024);
+      byte_vec_t payload(len);
+      std::generate(payload.begin(), payload.end(), [&]() { return byte_t(mt()); });
+
+      size_t const src_chunk = 1 + (mt() % 300);
+      size_t const dst_chunk = 1 + (mt() % 300);
+      REQUIRE(encode_incremental(payload, src_chunk, dst_chunk) == encode_single(payload));
+    }
   }
 }


### PR DESCRIPTION
Previously, incremental encoding still required a single large encoded buffer, but allowed clients to encode unrelated buffers (e.g. a frame header, then a frame body). This PR preserves that behavior but doesn't require a single large encoded buffer, allowing clients to "drain" cobs frames out incrementally without needing memory for the entire COBS frame.